### PR TITLE
CEDS-2380 Libraries upgrade for PRA

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,9 @@ lazy val microservice = (project in file("."))
   .settings(scoverageSettings)
 
 val compileDependencies = Seq(
-  "com.github.pureconfig"   %% "pureconfig"               % "0.12.2",
-  "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.3.0",
-  "uk.gov.hmrc"             %% "simple-reactivemongo"     % "7.23.0-play-26"
+  "com.github.pureconfig"   %% "pureconfig"               % "0.12.3",
+  "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.7.0",
+  "uk.gov.hmrc"             %% "simple-reactivemongo"     % "7.26.0-play-26"
 )
 
 val testDependencies = Seq(
@@ -57,7 +57,7 @@ val testDependencies = Seq(
   "com.typesafe.play"       %% "play-test"                % PlayVersion.current     % "test",
   "org.mockito"             %  "mockito-core"             % "2.27.0"                % "test",
   "org.pegdown"             %  "pegdown"                  % "1.6.0"                 % "test",
-  "uk.gov.hmrc"             %% "service-integration-test" % "0.10.0-play-26"        % "test",
+  "uk.gov.hmrc"             %% "service-integration-test" % "0.11.0-play-26"        % "test",
   "org.scalatestplus.play"  %% "scalatestplus-play"       % "3.1.2"                 % "test",
   "org.scalacheck"          %% "scalacheck"               % "1.14.0"                % "test"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 


### PR DESCRIPTION
Due to problem with simple-reactivemongo with sbt-plugin version 2.6.24 we need to stay with version 2.6.23.