### PR TITLE
[CEDS-2786] Add db migration feature

### DIFF
--- a/app/migrations/ExportsMigrationTool.scala
+++ b/app/migrations/ExportsMigrationTool.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import com.mongodb.client.MongoDatabase
+import play.api.Logger
+import uk.gov.hmrc.exports.migrations.changelogs.MigrationDefinition
+import uk.gov.hmrc.exports.migrations.exceptions.{ExportsMigrationException, LockManagerException}
+import uk.gov.hmrc.exports.migrations.repositories.ChangeEntry.{KeyAuthor, KeyChangeId}
+import uk.gov.hmrc.exports.migrations.repositories.{ChangeEntry, ChangeEntryRepository, LockRefreshChecker, LockRepository}
+
+object ExportsMigrationTool {
+
+  private val lockCollectionName = "exportsMigrationLock"
+  private val changeEntryCollectionName = "exportsMigrationChangeLog"
+
+  def apply(mongoDatabase: MongoDatabase, migrationsRegistry: MigrationsRegistry, lockManagerConfig: LockManagerConfig): ExportsMigrationTool = {
+    val lockRepository = new LockRepository(lockCollectionName, mongoDatabase)
+    val timeUtils = new TimeUtils
+    val lockRefreshChecker = new LockRefreshChecker(timeUtils)
+    val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, lockManagerConfig)
+    val changeEntryRepository = new ChangeEntryRepository(changeEntryCollectionName, mongoDatabase)
+
+    lockRepository.ensureIndex()
+    changeEntryRepository.ensureIndex()
+
+    new ExportsMigrationTool(lockManager, migrationsRegistry, changeEntryRepository, mongoDatabase)
+  }
+}
+
+class ExportsMigrationTool(
+  val lockManager: LockManager,
+  val migrationsRegistry: MigrationsRegistry,
+  val changeEntryRepository: ChangeEntryRepository,
+  val database: MongoDatabase,
+  val throwExceptionIfCannotObtainLock: Boolean = false
+) {
+
+  private val logger = Logger(this.getClass)
+
+  private var enabled: Boolean = true
+
+  def execute(): Unit =
+    if (!isEnabled) {
+      logger.info("ExportsMigrationTool is disabled. Exiting.")
+    } else
+      try {
+        lockManager.acquireLockDefault()
+        executeMigration()
+      } catch {
+        case lockEx: LockManagerException =>
+          if (throwExceptionIfCannotObtainLock) {
+            logger.error(lockEx.getMessage)
+            throw new ExportsMigrationException(lockEx.getMessage)
+          }
+          logger.warn(lockEx.getMessage)
+          logger.warn("ExportsMigrationTool did not acquire process lock. EXITING WITHOUT RUNNING DATA MIGRATION")
+      } finally {
+        lockManager.releaseLockDefault() //we do it anyway, it's idempotent
+
+        logger.info("ExportsMigrationTool has finished his job.")
+      }
+
+  def isEnabled: Boolean = enabled
+  private[migrations] def setEnabled(enabled: Boolean): Unit =
+    this.enabled = enabled
+
+  private def executeMigration(): Unit = {
+    logger.info(s"ExportsMigrationTool starting the data migration sequence.. ${migrationsRegistry.migrations.size}")
+
+    migrationsRegistry.migrations.sorted.foreach(executeIfNewOrRunAlways)
+  }
+
+  private def executeIfNewOrRunAlways(migrDefinition: MigrationDefinition): Unit = {
+    val changeEntry = ChangeEntry(migrDefinition)
+
+    try {
+      if (isNewChange(changeEntry)) {
+        lockManager.ensureLockDefault()
+        migrDefinition.migrationFunction(database)
+        changeEntryRepository.save(changeEntry)
+        logger.info(s"${changeEntry} applied")
+
+      } else if (isRunAlways(migrDefinition)) {
+        lockManager.ensureLockDefault()
+        migrDefinition.migrationFunction(database)
+        logger.info(s"${changeEntry} re-applied")
+
+      } else {
+        logger.info(s"${changeEntry} pass over")
+      }
+
+    } catch {
+      case exc: ExportsMigrationException => logger.error(exc.getMessage)
+    }
+  }
+
+  private def isNewChange(changeEntry: ChangeEntry): Boolean = !isExistingChange(changeEntry)
+
+  private def isExistingChange(changeEntry: ChangeEntry): Boolean = changeEntryRepository.findAll().exists { doc =>
+    doc.get(KeyChangeId) == changeEntry.changeId && doc.get(KeyAuthor) == changeEntry.author
+  }
+
+  private def isRunAlways(migrationDefinition: MigrationDefinition): Boolean = migrationDefinition.migrationInformation.runAlways
+
+}

--- a/app/migrations/LockManager.scala
+++ b/app/migrations/LockManager.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import java.util.{Date, UUID}
+
+import play.api.Logger
+import uk.gov.hmrc.exports.migrations.LockManager._
+import uk.gov.hmrc.exports.migrations.exceptions.{LockManagerException, LockPersistenceException}
+import uk.gov.hmrc.exports.migrations.repositories.{LockEntry, LockRefreshChecker, LockRepository, LockStatus}
+
+object LockManager {
+  val DefaultKey: String = "DEFAULT_LOCK"
+  val MinLockAcquiredForMillis: Long = 2L * 60L * 1000L // 2 minutes
+  val LockRefreshMarginMillis: Long = 60L * 1000L // 1 minute
+  val MinimumSleepThreadMillisDefault: Long = 500L
+}
+
+class LockManager(
+  val repository: LockRepository,
+  val lockRefreshChecker: LockRefreshChecker,
+  val timeUtils: TimeUtils,
+  val config: LockManagerConfig
+) {
+
+  private val logger = Logger(this.getClass)
+  private val lockOwner = UUID.randomUUID.toString
+
+  private var lockExpiresAt: Date = _
+  private var tries = 0
+
+  def acquireLockDefault(): Unit = acquireLock(DefaultKey)
+
+  private def acquireLock(lockKey: String): Unit = {
+    var keepLooping = true
+    do try {
+      logger.info("ExportsMigrationTool trying to acquire the lock")
+      val newLockExpiresAt = timeUtils.currentTimePlusMillis(config.lockAcquiredForMillis)
+      val lockEntry = new LockEntry(lockKey, LockStatus.LockHeld.name, lockOwner, newLockExpiresAt)
+      repository.insertUpdate(lockEntry)
+      updateStatus(newLockExpiresAt)
+      logger.info(s"ExportsMigrationTool acquired the lock until: ${newLockExpiresAt}")
+      keepLooping = false
+    } catch {
+      case _: LockPersistenceException =>
+        handleLockException(true)
+    } while ({
+      keepLooping
+    })
+  }
+
+  private[migrations] def ensureLockDefault(): Unit = ensureLock(DefaultKey)
+
+  private def ensureLock(lockKey: String): Unit = {
+    var keepLooping = true
+    // The first check will pass when there is no lock in the DB,
+    // but later it is not created, so it ends up in a loop doing nothing useful until lockMaxTries
+    do if (lockRefreshChecker.needsRefreshLock(lockExpiresAt)) try {
+      logger.info("ExportsMigrationTool trying to refresh the lock")
+      val lockExpiresAtTemp = timeUtils.currentTimePlusMillis(config.lockAcquiredForMillis)
+      val lockEntry = new LockEntry(lockKey, LockStatus.LockHeld.name, lockOwner, lockExpiresAtTemp)
+      repository.updateIfSameOwner(lockEntry)
+      updateStatus(lockExpiresAtTemp)
+      logger.info(s"ExportsMigrationTool refreshed the lock until: ${lockExpiresAtTemp}")
+      keepLooping = false
+    } catch {
+      case _: LockPersistenceException =>
+        handleLockException(false)
+    } else keepLooping = false while ({
+      keepLooping
+    })
+  }
+
+  private def updateStatus(lockExpiresAt: Date): Unit = {
+    this.lockExpiresAt = lockExpiresAt
+    this.tries = 0
+  }
+
+  private def handleLockException(acquiringLock: Boolean): Unit = {
+    this.tries += 1
+    if (this.tries >= config.lockMaxTries) {
+      updateStatus(null)
+      throw new LockManagerException("MaxTries(" + config.lockMaxTries + ") reached")
+    }
+    val currentLockOpt = repository.findByKey(DefaultKey)
+    // Check for ownership
+    currentLockOpt.filterNot(_.isOwner(lockOwner)).foreach { currentLock =>
+      val currentLockExpiresAt = currentLock.expiresAt
+      logger.info(s"Lock is taken by other process until: ${currentLockExpiresAt}")
+      if (!acquiringLock) throw new LockManagerException("Lock held by other process. Cannot ensure lock")
+      waitForLock(currentLockExpiresAt)
+    }
+  }
+
+  private def waitForLock(expiresAtMillis: Date): Unit = {
+    val diffMillis = expiresAtMillis.getTime - timeUtils.currentTime.getTime
+    val sleepingMillis = (if (diffMillis > 0) diffMillis else 0) + config.minimumSleepThreadMillis
+    try {
+      if (sleepingMillis > config.lockMaxWaitMillis)
+        throw new LockManagerException(maxWaitExceededErrorMsg(sleepingMillis))
+
+      logger.info(goingToSleepMsg(sleepingMillis))
+      Thread.sleep(sleepingMillis)
+    } catch {
+      case ex: InterruptedException =>
+        logger.error("ERROR acquiring lock: {}", ex)
+        Thread.currentThread.interrupt()
+    }
+  }
+
+  private def maxWaitExceededErrorMsg(sleepingMillis: Long): String =
+    s"Waiting time required (${sleepingMillis} ms) to take the lock is longer than maxWaitingTime (${config.lockMaxWaitMillis} ms)"
+
+  private def goingToSleepMsg(sleepingMillis: Long): String =
+    s"ExportsMigrationTool is going to sleep to wait for the lock:  ${sleepingMillis} ms (${timeUtils.millisToMinutes(sleepingMillis)} minutes)"
+
+  def releaseLockDefault(): Unit = releaseLock(DefaultKey)
+
+  private def releaseLock(lockKey: String): Unit = {
+    logger.info("ExportsMigrationTool is trying to release the lock.")
+    repository.removeByKeyAndOwner(lockKey, this.lockOwner)
+    this.lockExpiresAt = null
+    logger.info("ExportsMigrationTool released the lock")
+  }
+
+}

--- a/app/migrations/LockManagerConfig.scala
+++ b/app/migrations/LockManagerConfig.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import uk.gov.hmrc.exports.migrations.LockManager.{MinLockAcquiredForMillis, MinimumSleepThreadMillisDefault}
+
+case class LockManagerConfig(
+  lockMaxTries: Int = 1,
+  lockMaxWaitMillis: Long = MinLockAcquiredForMillis + 60L * 1000L,
+  lockAcquiredForMillis: Long = MinLockAcquiredForMillis,
+  minimumSleepThreadMillis: Long = MinimumSleepThreadMillisDefault
+)

--- a/app/migrations/MigrationRoutine.scala
+++ b/app/migrations/MigrationRoutine.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import com.google.inject.Singleton
+import com.mongodb.{MongoClient, MongoClientURI}
+import config.AppConfig
+import javax.inject.Inject
+import play.api.Logger
+import uk.gov.hmrc.exports.routines.{Routine, RoutinesExecutionContext}
+
+import scala.concurrent.Future
+
+@Singleton
+class MigrationRoutine @Inject()(appConfig: AppConfig)(implicit mec: RoutinesExecutionContext) extends Routine {
+
+  private val logger = Logger(this.getClass)
+
+  private val uri = new MongoClientURI(appConfig.mongodb.uri.replaceAllLiterally("sslEnabled", "ssl"))
+  private val client = new MongoClient(uri)
+  private val db = client.getDatabase(uri.getDatabase)
+
+  def execute(): Future[Unit] = Future {
+    logger.info("Exports Migration feature enabled. Starting migration with ExportsMigrationTool")
+    migrateWithExportsMigrationTool()
+  }
+
+  private def migrateWithExportsMigrationTool(): Unit = {
+    val lockManagerConfig = LockManagerConfig(lockMaxTries = 10, lockMaxWaitMillis = minutesToMillis(5), lockAcquiredForMillis = minutesToMillis(3))
+    val migrationsRegistry = MigrationsRegistry()
+    val migrationTool = ExportsMigrationTool(db, migrationsRegistry, lockManagerConfig)
+
+    migrationTool.execute()
+    client.close()
+  }
+
+  private def minutesToMillis(minutes: Int): Long = minutes * 60L * 1000L
+}

--- a/app/migrations/MigrationsRegistry.scala
+++ b/app/migrations/MigrationsRegistry.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import uk.gov.hmrc.exports.migrations.changelogs.MigrationDefinition
+
+case class MigrationsRegistry(migrations: Seq[MigrationDefinition] = Seq.empty) {
+
+  def register(definition: MigrationDefinition): MigrationsRegistry =
+    this.copy(migrations = this.migrations :+ definition)
+}

--- a/app/migrations/TimeUtils.scala
+++ b/app/migrations/TimeUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import java.util.Date
+
+class TimeUtils {
+
+  private[migrations] def currentTimePlusMillis(millis: Long): Date =
+    new Date(System.currentTimeMillis + millis)
+
+  private[migrations] def currentTime: Date =
+    new Date(System.currentTimeMillis)
+
+  private[migrations] def minutesToMillis(minutes: Long): Long =
+    minutes * 60 * 1000
+
+  private[migrations] def millisToMinutes(millis: Long): Long =
+    millis / (60 * 1000)
+
+}

--- a/app/migrations/changelogs/MigrationDefinition.scala
+++ b/app/migrations/changelogs/MigrationDefinition.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs
+
+import com.mongodb.client.MongoDatabase
+
+trait MigrationDefinition {
+  val migrationInformation: MigrationInformation
+  def migrationFunction(db: MongoDatabase): Unit
+}
+
+object MigrationDefinition {
+  implicit val ordering: Ordering[MigrationDefinition] = Ordering.by(_.migrationInformation)
+}

--- a/app/migrations/changelogs/MigrationInformation.scala
+++ b/app/migrations/changelogs/MigrationInformation.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs
+
+case class MigrationInformation(id: String, order: Int, author: String, runAlways: Boolean = false)
+
+object MigrationInformation {
+  implicit val ordering: Ordering[MigrationInformation] = Ordering.by(_.order)
+}

--- a/app/migrations/exceptions/ExportsMigrationException.scala
+++ b/app/migrations/exceptions/ExportsMigrationException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.exceptions
+
+class ExportsMigrationException(message: String) extends RuntimeException(message)

--- a/app/migrations/exceptions/LockManagerException.scala
+++ b/app/migrations/exceptions/LockManagerException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.exceptions
+
+class LockManagerException(message: String) extends RuntimeException(message)

--- a/app/migrations/exceptions/LockPersistenceException.scala
+++ b/app/migrations/exceptions/LockPersistenceException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.exceptions
+
+class LockPersistenceException(message: String) extends RuntimeException(message)

--- a/app/migrations/repositories/ChangeEntry.scala
+++ b/app/migrations/repositories/ChangeEntry.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import org.bson.Document
+import uk.gov.hmrc.exports.migrations.changelogs.MigrationDefinition
+import uk.gov.hmrc.exports.migrations.repositories.ChangeEntry._
+
+object ChangeEntry {
+  private[migrations] val KeyChangeId: String = "changeId"
+  private[migrations] val KeyAuthor: String = "author"
+  private[migrations] val KeyTimestamp: String = "timestamp"
+  private[migrations] val KeyChangeLogClass: String = "changeLogClass"
+
+  def apply(migrationDefinition: MigrationDefinition): ChangeEntry = ChangeEntry(
+    changeId = migrationDefinition.migrationInformation.id,
+    author = migrationDefinition.migrationInformation.author,
+    timestamp = new Date(),
+    changeLogClass = migrationDefinition.getClass.getSimpleName
+  )
+}
+
+case class ChangeEntry(changeId: String, author: String, timestamp: Date, changeLogClass: String) {
+
+  private[migrations] def buildFullDBObject: Document = {
+    val entry: Document = new Document
+    entry
+      .append(KeyChangeId, this.changeId)
+      .append(KeyAuthor, this.author)
+      .append(KeyTimestamp, this.timestamp)
+      .append(KeyChangeLogClass, this.changeLogClass)
+  }
+}

--- a/app/migrations/repositories/ChangeEntryRepository.scala
+++ b/app/migrations/repositories/ChangeEntryRepository.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import com.mongodb.client.MongoDatabase
+import org.bson.Document
+import uk.gov.hmrc.exports.migrations.repositories.ChangeEntry.{KeyAuthor, KeyChangeId}
+
+import scala.collection.JavaConverters.asScalaIterator
+
+class ChangeEntryRepository(collectionName: String, mongoDatabase: MongoDatabase)
+    extends MongoRepository(mongoDatabase, collectionName, Array(KeyAuthor, KeyChangeId)) {
+
+  private[migrations] def findAll(): List[Document] = asScalaIterator(collection.find().iterator()).toList
+
+  private[migrations] def save(changeEntry: ChangeEntry): Unit = collection.insertOne(changeEntry.buildFullDBObject)
+
+}

--- a/app/migrations/repositories/LockEntry.scala
+++ b/app/migrations/repositories/LockEntry.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import org.bson.Document
+import uk.gov.hmrc.exports.migrations.repositories.LockEntry._
+
+object LockEntry {
+  private[migrations] val KeyField: String = "key"
+  private[migrations] val StatusField: String = "status"
+  private[migrations] val OwnerField: String = "owner"
+  private[migrations] val ExpiresAtField: String = "expiresAt"
+
+  def apply(document: Document): LockEntry = LockEntry(
+    document.getString(LockEntry.KeyField),
+    document.getString(LockEntry.StatusField),
+    document.getString(LockEntry.OwnerField),
+    document.getDate(LockEntry.ExpiresAtField)
+  )
+}
+
+case class LockEntry(key: String, status: String, owner: String, expiresAt: Date) {
+
+  private[migrations] def buildFullDBObject: Document = {
+    val entry: Document = new Document
+    entry.append(KeyField, this.key).append(StatusField, this.status).append(OwnerField, this.owner).append(ExpiresAtField, this.expiresAt)
+  }
+
+  private[migrations] def isOwner(owner: String): Boolean = this.owner == owner
+
+}

--- a/app/migrations/repositories/LockRefreshChecker.scala
+++ b/app/migrations/repositories/LockRefreshChecker.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import uk.gov.hmrc.exports.migrations.LockManager.LockRefreshMarginMillis
+import uk.gov.hmrc.exports.migrations.TimeUtils
+
+class LockRefreshChecker(private val timeUtils: TimeUtils) {
+  def needsRefreshLock(lockExpiresAt: Date): Boolean =
+    lockExpiresAt == null ||
+      timeUtils.currentTime.compareTo(new Date(lockExpiresAt.getTime - timeUtils.minutesToMillis(LockRefreshMarginMillis))) >= 0
+
+}

--- a/app/migrations/repositories/LockRepository.scala
+++ b/app/migrations/repositories/LockRepository.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import com.mongodb.client.MongoDatabase
+import com.mongodb.client.model.Filters.{and, lt, or, eq => feq}
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.result.UpdateResult
+import com.mongodb.{DuplicateKeyException, ErrorCategory, MongoWriteException}
+import org.bson.Document
+import org.bson.conversions.Bson
+import uk.gov.hmrc.exports.migrations.exceptions.LockPersistenceException
+import uk.gov.hmrc.exports.migrations.repositories.LockEntry.{ExpiresAtField, KeyField, OwnerField, StatusField}
+
+import scala.collection.JavaConverters.asScalaIterator
+
+class LockRepository(collectionName: String, db: MongoDatabase) extends MongoRepository(db, collectionName, Array(KeyField)) {
+
+  /**
+    * Retrieves a lock by key
+    *
+    * @param lockKey key
+    * @return LockEntry
+    */
+  private[migrations] def findByKey(lockKey: String): Option[LockEntry] =
+    asScalaIterator(collection.find(new Document().append(KeyField, lockKey)).iterator).toSeq.headOption
+      .map(LockEntry(_))
+
+  /**
+    * Removes from database all the locks with the same key (only can be one) and owner
+    *
+    * @param lockKey lock key
+    * @param owner   lock owner
+    */
+  private[migrations] def removeByKeyAndOwner(lockKey: String, owner: String): Unit =
+    collection.deleteMany(and(feq(KeyField, lockKey), feq(OwnerField, owner)))
+
+  /**
+    * If there is a lock in the database with the same key, updates it if either is expired or both share the same owner.
+    * If there is no lock with the same key, it's inserted.
+    *
+    * @param newLock lock to replace the existing one or be inserted.
+    * @throws LockPersistenceException if there is a lock in database with same key, but belongs to another owner
+    *                                   and is not expired or cannot insert/update the lock for any other reason
+    */
+  private[migrations] def insertUpdate(newLock: LockEntry): Unit =
+    insertUpdate(newLock, onlyIfSameOwner = false)
+
+  /**
+    * If there is a lock in the database with the same key and owner, updates it. Otherwise throws a LockPersistenceException
+    *
+    * @param newLock lock to replace the existing one.
+    * @throws LockPersistenceException if there is no lock in the database with the same key and owner or cannot update
+    *                                  the lock for any other reason
+    */
+  private[migrations] def updateIfSameOwner(newLock: LockEntry): Unit =
+    insertUpdate(newLock, onlyIfSameOwner = true)
+
+  private def insertUpdate(newLock: LockEntry, onlyIfSameOwner: Boolean): Unit =
+    try {
+      val acquireLockQuery: Bson = getAcquireLockQuery(newLock.key, newLock.owner, onlyIfSameOwner)
+      val result: UpdateResult = collection.updateMany(
+        acquireLockQuery,
+        new Document().append("$set", newLock.buildFullDBObject),
+        new UpdateOptions().upsert(!onlyIfSameOwner)
+      )
+      if (result.getModifiedCount <= 0 && result.getUpsertedId == null)
+        throw new LockPersistenceException("Lock is held")
+    } catch {
+      case ex: MongoWriteException if ex.getError.getCategory == ErrorCategory.DUPLICATE_KEY =>
+        throw new LockPersistenceException("Lock is held")
+      case _: DuplicateKeyException =>
+        throw new LockPersistenceException("Lock is held")
+    }
+
+  private def getAcquireLockQuery(lockKey: String, owner: String, onlyIfSameOwner: Boolean): Bson = {
+    val expiresAtCond: Bson = lt(ExpiresAtField, new Date)
+    val ownerCond: Bson = feq(OwnerField, owner)
+    val orCond: Bson = if (onlyIfSameOwner) {
+      or(ownerCond)
+    } else {
+      or(expiresAtCond, ownerCond)
+    }
+    and(feq(KeyField, lockKey), feq(StatusField, LockStatus.LockHeld.name), orCond)
+  }
+
+}

--- a/app/migrations/repositories/LockStatus.scala
+++ b/app/migrations/repositories/LockStatus.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+sealed abstract class LockStatus(val name: String)
+
+object LockStatus {
+  case object LockHeld extends LockStatus("LockHeld")
+}

--- a/app/migrations/repositories/MongoRepository.scala
+++ b/app/migrations/repositories/MongoRepository.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import com.mongodb.client.MongoDatabase
+import com.mongodb.client.model.IndexOptions
+import org.bson.Document
+import play.api.Logger
+
+import scala.collection.JavaConverters.asScalaIterator
+
+abstract class MongoRepository private[migrations] (val mongoDatabase: MongoDatabase, val collectionName: String, val uniqueFields: Array[String]) {
+
+  private val logger = Logger(this.getClass)
+  private var ensuredCollectionIndex = false
+
+  private[migrations] val collection = mongoDatabase.getCollection(collectionName)
+  private[migrations] val fullCollectionName = collection.getNamespace.getDatabaseName + "." + collection.getNamespace.getCollectionName
+
+  private lazy val indexes: Seq[Document] = asScalaIterator(collection.listIndexes.iterator()).toSeq
+
+  private[migrations] def ensureIndex(): Unit =
+    if (!this.ensuredCollectionIndex) {
+      indexes.size match {
+        case 0 =>
+          createRequiredUniqueIndex()
+          logger.debug(s"Index in collection ${getCollectionName} was created")
+        case _ =>
+          indexes.filter(!isIndexUnique(_)).foreach(dropIndex)
+
+          if (indexes.exists(isIndexUnique)) {
+            logger.debug(s"Index in collection ${getCollectionName} already exists")
+          } else {
+            createRequiredUniqueIndex()
+            logger.debug(s"Index in collection ${getCollectionName} was recreated")
+          }
+      }
+      this.ensuredCollectionIndex = true
+    }
+
+  // Index is considered unique when:
+  // 1. Name is "_id_" (these are implicitly unique https://docs.mongodb.com/manual/indexes/index.html#default-id-index)
+  // 2. Every uniqueField value is equal 1
+  // 3. "ns" field contains fullCollectionName
+  // 4. "unique" field is true
+  private def isIndexUnique(index: Document): Boolean = {
+    val key = index.get("key").asInstanceOf[Document]
+
+    if (index.getString("name").equals("_id_")) return true
+
+    for (uniqueField <- uniqueFields) {
+      if (key.getInteger(uniqueField, 0) != 1) return false
+    }
+
+    fullCollectionName == index.getString("ns") && index.getBoolean("unique", false)
+  }
+
+  private[migrations] def createRequiredUniqueIndex(): Unit =
+    collection.createIndex(getIndexDocument(uniqueFields), new IndexOptions().unique(true))
+
+  private def getIndexDocument(uniqueFields: Array[String]): Document = {
+    val indexDocument = new Document
+    for (field <- uniqueFields) {
+      indexDocument.append(field, 1)
+    }
+    indexDocument
+  }
+
+  private def getCollectionName = collection.getNamespace.getCollectionName
+
+  private[migrations] def dropIndex(index: Document): Unit =
+    collection.dropIndex(index.get("name").toString)
+}

--- a/app/routines/Routine.scala
+++ b/app/routines/Routine.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import scala.concurrent.Future
+
+trait Routine {
+  def execute(): Future[Unit]
+}

--- a/app/routines/RoutineRunner.scala
+++ b/app/routines/RoutineRunner.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import akka.actor.{ActorSystem, Cancellable}
+import javax.inject.Inject
+import play.api.inject.ApplicationLifecycle
+import uk.gov.hmrc.exports.migrations.MigrationRoutine
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class RoutineRunner @Inject()(migrationRunner: MigrationRoutine, actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle)(
+  implicit mec: RoutinesExecutionContext
+) {
+
+  val migrationTask: Cancellable = actorSystem.scheduler.scheduleOnce(0.seconds) {
+    for {
+      _ <- migrationRunner.execute()
+    } yield (())
+  }
+
+  applicationLifecycle.addStopHook(() => Future.successful(migrationTask.cancel()))
+}

--- a/app/routines/RoutineRunnerModule.scala
+++ b/app/routines/RoutineRunnerModule.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import play.api.inject._
+
+class RoutineRunnerModule extends SimpleModule(bind[RoutineRunner].toSelf.eagerly())

--- a/app/routines/RoutinesExecutionContext.scala
+++ b/app/routines/RoutinesExecutionContext.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import akka.actor.ActorSystem
+import javax.inject.{Inject, Singleton}
+import play.api.libs.concurrent.CustomExecutionContext
+
+@Singleton
+class RoutinesExecutionContext @Inject()(actorSystem: ActorSystem) extends CustomExecutionContext(actorSystem, "contexts.routines-dispatcher") {}

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,9 @@ lazy val microservice = (project in file("."))
 val compileDependencies = Seq(
   "com.github.pureconfig"   %% "pureconfig"                   % "0.12.3",
   "uk.gov.hmrc"             %% "bootstrap-backend-play-26"    % "2.24.0",
-  "uk.gov.hmrc"             %% "simple-reactivemongo"         % "7.26.0-play-26"
+  "uk.gov.hmrc"             %% "simple-reactivemongo"         % "7.30.0-play-26",
+  "org.mongodb.scala"       %% "mongo-scala-driver"           % "2.9.0",
+  "org.mongodb"             %  "mongo-java-driver"            % "3.5.0"
 )
 
 val testDependencies = Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,6 +36,9 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.MicroserviceModule"
 play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.MicroserviceFilters"
 
+# A utility that runs registerd routines on application startup
+play.modules.enabled += "uk.gov.hmrc.exports.routines.RoutineRunnerModule"
+
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
@@ -133,4 +136,14 @@ microservice {
 
 notifications {
   ttl-seconds = 3600
+}
+
+contexts {
+    routines-dispatcher {
+        fork-join-executor {
+            parallelism-min = 2
+            parallalism-factor = 2.0
+            parallelism-max = 20
+        }
+    }
 }

--- a/precheck.sh
+++ b/precheck.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sbt clean coverage test it:test scalafmt::test test:scalafmt::test scalastyle coverageReport

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,119 @@
+<scalastyle>
+    <name>Scalastyle standard configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
+        <parameters>
+            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[println]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
+        <parameters>
+            <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+</scalastyle>

--- a/test/unit/migrations/ExportsMigrationToolSpec.scala
+++ b/test/unit/migrations/ExportsMigrationToolSpec.scala
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import java.util.Date
+
+import com.mongodb.client.MongoDatabase
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+import uk.gov.hmrc.exports.migrations.exceptions.{ExportsMigrationException, LockManagerException}
+import uk.gov.hmrc.exports.migrations.repositories.{ChangeEntry, ChangeEntryRepository}
+
+class ExportsMigrationToolSpec extends WordSpec with MockitoSugar with MustMatchers with BeforeAndAfterEach {
+
+  private val lockManager: LockManager = mock[LockManager]
+  private val migrationsRegistry: MigrationsRegistry = mock[MigrationsRegistry]
+  private val changeEntryRepository: ChangeEntryRepository = mock[ChangeEntryRepository]
+  private val database: MongoDatabase = mock[MongoDatabase]
+
+  private def exportsMigrationTool(throwExceptionIfCannotObtainLock: Boolean = false) =
+    new ExportsMigrationTool(lockManager, migrationsRegistry, changeEntryRepository, database, throwExceptionIfCannotObtainLock)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(lockManager, migrationsRegistry, changeEntryRepository, database)
+    when(migrationsRegistry.migrations).thenReturn(Seq.empty)
+  }
+
+  override def afterEach(): Unit = {
+    reset(lockManager, migrationsRegistry, changeEntryRepository, database)
+
+    super.afterEach()
+  }
+
+  "ExportsMigrationTool on execute" should {
+
+    "call LockManager acquireLockDefault method" in {
+
+      exportsMigrationTool().execute()
+      verify(lockManager).acquireLockDefault()
+    }
+
+    "call LockManager releaseLockDefault method" in {
+
+      exportsMigrationTool().execute()
+      verify(lockManager).releaseLockDefault()
+    }
+  }
+
+  "ExportsMigrationTool on execute" when {
+
+    "MigrationsRegistry is empty" should {
+
+      "not call LockManager ensureLockDefault" in {
+
+        exportsMigrationTool().execute()
+        verify(lockManager, never()).ensureLockDefault()
+      }
+
+      "not call ChangeEntryRepository" in {
+
+        exportsMigrationTool().execute()
+        verifyNoInteractions(changeEntryRepository)
+      }
+    }
+
+    "MigrationsRegistry contains new migration definition" should {
+
+      val testMigrationInformation = MigrationInformation(id = "TestId", order = 1, author = "TestAuthor")
+      val migrationDefinition = new MigrationDefinition {
+        override val migrationInformation: MigrationInformation = testMigrationInformation
+        override def migrationFunction(db: MongoDatabase): Unit = {}
+      }
+
+      "call ChangeEntryRepository findAll method" in {
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition))
+        when(changeEntryRepository.findAll()).thenReturn(List.empty)
+
+        exportsMigrationTool().execute()
+
+        verify(changeEntryRepository).findAll()
+      }
+
+      "call LockManager ensureLockDefault" in {
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition))
+        when(changeEntryRepository.findAll()).thenReturn(List.empty)
+
+        exportsMigrationTool().execute()
+
+        verify(lockManager).ensureLockDefault()
+      }
+
+      "call ChangeEntryRepository save method" in {
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition))
+        when(changeEntryRepository.findAll()).thenReturn(List.empty)
+
+        exportsMigrationTool().execute()
+
+        verify(changeEntryRepository).save(any[ChangeEntry])
+      }
+    }
+
+    "MigrationsRegistry contains old migration definition with runAlways flag" should {
+
+      val testMigrationInformation = MigrationInformation(id = "TestId", order = 1, author = "TestAuthor", runAlways = true)
+      val migrationDefinition = new MigrationDefinition {
+        override val migrationInformation: MigrationInformation = testMigrationInformation
+        override def migrationFunction(db: MongoDatabase): Unit = {}
+      }
+      val currentChangeEntry = ChangeEntry(
+        changeId = testMigrationInformation.id,
+        author = testMigrationInformation.author,
+        timestamp = new Date(),
+        changeLogClass = "testChangeLogClass"
+      )
+
+      "call ChangeEntryRepository findAll method" in {
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition))
+        when(changeEntryRepository.findAll()).thenReturn(List(currentChangeEntry.buildFullDBObject))
+
+        exportsMigrationTool().execute()
+
+        verify(changeEntryRepository).findAll()
+      }
+
+      "call LockManager ensureLockDefault" in {
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition))
+        when(changeEntryRepository.findAll()).thenReturn(List(currentChangeEntry.buildFullDBObject))
+
+        exportsMigrationTool().execute()
+
+        verify(lockManager).ensureLockDefault()
+      }
+
+      "not call ChangeEntryRepository save method" in {
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition))
+        when(changeEntryRepository.findAll()).thenReturn(List(currentChangeEntry.buildFullDBObject))
+
+        exportsMigrationTool().execute()
+
+        verify(changeEntryRepository, never()).save(any[ChangeEntry])
+      }
+    }
+
+    "MigrationsRegistry contains multiple new migration definitions" should {
+
+      "execute them in order" in {
+
+        def testMigrationInformation(order: Int) = MigrationInformation(id = "TestId", order = order, author = "TestAuthor")
+        val migrationDefinition_1 = mock[MigrationDefinition]
+        val migrationDefinition_2 = mock[MigrationDefinition]
+        val migrationDefinition_3 = mock[MigrationDefinition]
+        when(migrationDefinition_1.migrationInformation).thenReturn(testMigrationInformation(1))
+        when(migrationDefinition_2.migrationInformation).thenReturn(testMigrationInformation(2))
+        when(migrationDefinition_3.migrationInformation).thenReturn(testMigrationInformation(3))
+
+        when(migrationsRegistry.migrations).thenReturn(Seq(migrationDefinition_2, migrationDefinition_3, migrationDefinition_1))
+        when(changeEntryRepository.findAll()).thenReturn(List.empty)
+
+        exportsMigrationTool().execute()
+
+        val inOrder = Mockito.inOrder(migrationDefinition_1, migrationDefinition_2, migrationDefinition_3)
+        inOrder.verify(migrationDefinition_1).migrationFunction(any[MongoDatabase])
+        inOrder.verify(migrationDefinition_2).migrationFunction(any[MongoDatabase])
+        inOrder.verify(migrationDefinition_3).migrationFunction(any[MongoDatabase])
+      }
+    }
+
+    "LockManager throws LockManagerException" when {
+
+      "throwExceptionIfCannotObtainLock == true" should {
+
+        "throw ExportsMigrationException" in {
+
+          val exceptionMessage = "Test Exception Message"
+          when(lockManager.acquireLockDefault()).thenThrow(new LockManagerException(exceptionMessage))
+
+          intercept[ExportsMigrationException] {
+            exportsMigrationTool(throwExceptionIfCannotObtainLock = true).execute()
+          }.getMessage mustBe exceptionMessage
+        }
+
+        "call LockManager releaseLockDefault method" in {
+
+          val exceptionMessage = "Test Exception Message"
+          when(lockManager.acquireLockDefault()).thenThrow(new LockManagerException(exceptionMessage))
+
+          intercept[ExportsMigrationException] {
+            exportsMigrationTool(throwExceptionIfCannotObtainLock = true).execute()
+          }
+
+          verify(lockManager).releaseLockDefault()
+        }
+      }
+
+      "throwExceptionIfCannotObtainLock == false" should {
+
+        "not throw ExportsMigrationException" in {
+
+          val exceptionMessage = "Test Exception Message"
+          when(lockManager.acquireLockDefault()).thenThrow(new LockManagerException(exceptionMessage))
+
+          noException shouldBe thrownBy(exportsMigrationTool().execute())
+        }
+
+        "call LockManager releaseLockDefault method" in {
+
+          val exceptionMessage = "Test Exception Message"
+          when(lockManager.acquireLockDefault()).thenThrow(new LockManagerException(exceptionMessage))
+
+          exportsMigrationTool().execute()
+
+          verify(lockManager).releaseLockDefault()
+        }
+      }
+    }
+  }
+
+}

--- a/test/unit/migrations/LockManagerSpec.scala
+++ b/test/unit/migrations/LockManagerSpec.scala
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import java.util.Date
+
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.exports.migrations.LockManager.DefaultKey
+import uk.gov.hmrc.exports.migrations.exceptions.{LockManagerException, LockPersistenceException}
+import uk.gov.hmrc.exports.migrations.repositories.{LockEntry, LockRefreshChecker, LockRepository, LockStatus}
+
+class LockManagerSpec extends WordSpec with MockitoSugar with MustMatchers with BeforeAndAfterEach {
+
+  private val lockRepository = mock[LockRepository]
+  private val lockRefreshChecker = mock[LockRefreshChecker]
+  private val timeUtils = mock[TimeUtils]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(lockRepository, lockRefreshChecker, timeUtils)
+    when(timeUtils.currentTime).thenCallRealMethod()
+    when(timeUtils.minutesToMillis(any())).thenCallRealMethod()
+    when(timeUtils.millisToMinutes(any())).thenCallRealMethod()
+  }
+
+  override def afterEach(): Unit = {
+    reset(lockRepository, lockRefreshChecker, timeUtils)
+
+    super.afterEach()
+  }
+
+  private def lockEntryPassedToLockRepositoryOnAcquireLock: LockEntry = {
+    val captor: ArgumentCaptor[LockEntry] = ArgumentCaptor.forClass(classOf[LockEntry])
+    verify(lockRepository).insertUpdate(captor.capture())
+    captor.getValue
+  }
+
+  private def lockEntryPassedToLockRepositoryOnEnsureLock: LockEntry = {
+    val captor: ArgumentCaptor[LockEntry] = ArgumentCaptor.forClass(classOf[LockEntry])
+    verify(lockRepository).updateIfSameOwner(captor.capture())
+    captor.getValue
+  }
+
+  private val lockMaxTries = 3
+  private val lockAliveTimeMillis = 500L
+  private val config = LockManagerConfig(
+    lockMaxTries = lockMaxTries,
+    lockMaxWaitMillis = 2 * lockAliveTimeMillis,
+    lockAcquiredForMillis = lockAliveTimeMillis,
+    minimumSleepThreadMillis = 100L
+  )
+  private val newLockExpiryDate = new Date(System.currentTimeMillis + lockAliveTimeMillis)
+  private val currentLockExpiryDate = newLockExpiryDate
+
+  "LockManager on acquireLockDefault" should {
+    "provide LockRepository with correct LockEntry" in {
+
+      when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+      doNothing().when(lockRepository).insertUpdate(any())
+
+      val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+      lockManager.acquireLockDefault()
+
+      lockEntryPassedToLockRepositoryOnAcquireLock.key mustBe DefaultKey
+      lockEntryPassedToLockRepositoryOnAcquireLock.status mustBe LockStatus.LockHeld.name
+      lockEntryPassedToLockRepositoryOnAcquireLock.owner mustNot be(empty)
+      lockEntryPassedToLockRepositoryOnAcquireLock.expiresAt must be(newLockExpiryDate)
+    }
+  }
+
+  "LockManager on acquireLockDefault" when {
+
+    "no exception thrown by LockRepository (no lock in DB, lock belongs to this LockManager, or to some other but is expired)" should {
+      "call LockRepository only once" in {
+
+        when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+        doNothing().when(lockRepository).insertUpdate(any())
+
+        val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+        lockManager.acquireLockDefault()
+
+        verify(lockRepository).insertUpdate(any())
+      }
+    }
+
+    "LockPersistenceException is thrown by LockRepository" when {
+
+      "current lock belongs to different owner and it's not expired" should {
+
+        "call LockRepository up to maxTries times" in {
+
+          when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+          val currentLock = LockEntry(DefaultKey, LockStatus.LockHeld.name, "OtherLockOwner", currentLockExpiryDate)
+          when(lockRepository.insertUpdate(any())).thenThrow(new LockPersistenceException("Lock is held"))
+          when(lockRepository.findByKey(anyString())).thenReturn(Some(currentLock))
+
+          val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+          intercept[LockManagerException](lockManager.acquireLockDefault())
+
+          verify(lockRepository, times(lockMaxTries)).insertUpdate(any())
+        }
+
+        "throw LockCheckException('MaxTries(_) reached') after not succeeding any try" in {
+
+          when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+          val currentLock = LockEntry(DefaultKey, LockStatus.LockHeld.name, "OtherLockOwner", currentLockExpiryDate)
+          when(lockRepository.insertUpdate(any())).thenThrow(new LockPersistenceException("Lock is held"))
+          when(lockRepository.findByKey(anyString())).thenReturn(Some(currentLock))
+
+          val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+          intercept[LockManagerException](lockManager.acquireLockDefault()).getMessage mustBe s"MaxTries($lockMaxTries) reached"
+        }
+
+        "throw LockCheckException('Waiting time required...') if lock's expiry date is further in the future than lockMaxWaitMillis" in {
+
+          when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+
+          val currentLockExpiryDate = new Date(newLockExpiryDate.getTime + 10 * config.lockMaxWaitMillis)
+          val currentLock = LockEntry(DefaultKey, LockStatus.LockHeld.name, "OtherLockOwner", currentLockExpiryDate)
+          when(lockRepository.insertUpdate(any())).thenThrow(new LockPersistenceException("Lock is held"))
+          when(lockRepository.findByKey(anyString())).thenReturn(Some(currentLock))
+
+          val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+          intercept[LockManagerException](lockManager.acquireLockDefault()).getMessage must include("Waiting time required")
+        }
+      }
+    }
+  }
+
+  "LockManager on ensureLockDefault" when {
+
+    "does need to refresh the lock" should {
+      "provide LockRepository with correct LockEntry" in {
+
+        when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+        doNothing().when(lockRepository).updateIfSameOwner(any())
+        when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(true)
+
+        val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+        lockManager.ensureLockDefault()
+
+        lockEntryPassedToLockRepositoryOnEnsureLock.key mustBe DefaultKey
+        lockEntryPassedToLockRepositoryOnEnsureLock.status mustBe LockStatus.LockHeld.name
+        lockEntryPassedToLockRepositoryOnEnsureLock.owner mustNot be(empty)
+        lockEntryPassedToLockRepositoryOnEnsureLock.expiresAt must be(newLockExpiryDate)
+      }
+    }
+  }
+
+  "LockManager on ensureLockDefault" when {
+
+    "does NOT need to refresh the lock" should {
+      "not call LockRepository" in {
+
+        when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(false)
+
+        val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+        lockManager.ensureLockDefault()
+
+        verifyNoInteractions(lockRepository)
+      }
+    }
+
+    "does need to refresh the lock" when {
+
+      "LockRepository does not throw any exceptions (there is a lock belonging to this LockManager)" should {
+        "call LockRepository only once" in {
+
+          when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(true)
+          when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+          doNothing().when(lockRepository).updateIfSameOwner(any())
+
+          val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+          lockManager.ensureLockDefault()
+
+          verify(lockRepository).updateIfSameOwner(any())
+        }
+      }
+
+      "LockPersistenceException is thrown by LockRepository" when {
+
+        "there is no lock in the DB" should {
+
+          "call LockRepository maxTries times" in {
+
+            when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(true)
+            when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+            when(lockRepository.updateIfSameOwner(any())).thenThrow(new LockPersistenceException("Lock is held"))
+            when(lockRepository.findByKey(anyString())).thenReturn(None)
+
+            val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+            intercept[LockManagerException](lockManager.ensureLockDefault())
+
+            verify(lockRepository, times(lockMaxTries)).updateIfSameOwner(any())
+          }
+
+          "throw LockCheckException('MaxTries(_) reached')" in {
+
+            when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(true)
+            when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+            when(lockRepository.updateIfSameOwner(any())).thenThrow(new LockPersistenceException("Lock is held"))
+            when(lockRepository.findByKey(anyString())).thenReturn(None)
+
+            val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+            intercept[LockManagerException](lockManager.ensureLockDefault()).getMessage mustBe s"MaxTries($lockMaxTries) reached"
+          }
+        }
+
+        "there is a lock belonging to some other LockManager (expired or not)" should {
+
+          "call LockRepository only once" in {
+
+            when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(true)
+            when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+            val currentLock = LockEntry(DefaultKey, LockStatus.LockHeld.name, "OtherLockOwner", currentLockExpiryDate)
+            when(lockRepository.updateIfSameOwner(any())).thenThrow(new LockPersistenceException("Lock is held"))
+            when(lockRepository.findByKey(anyString())).thenReturn(Some(currentLock))
+
+            val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+            intercept[LockManagerException](lockManager.ensureLockDefault())
+
+            verify(lockRepository).updateIfSameOwner(any())
+          }
+
+          "throw LockCheckException('Lock held by other process. Cannot ensure lock')" in {
+
+            when(lockRefreshChecker.needsRefreshLock(any())).thenReturn(true)
+            when(timeUtils.currentTimePlusMillis(any())).thenReturn(newLockExpiryDate)
+            val currentLock = LockEntry(DefaultKey, LockStatus.LockHeld.name, "OtherLockOwner", currentLockExpiryDate)
+            when(lockRepository.updateIfSameOwner(any())).thenThrow(new LockPersistenceException("Lock is held"))
+            when(lockRepository.findByKey(anyString())).thenReturn(Some(currentLock))
+
+            val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+            intercept[LockManagerException](lockManager.ensureLockDefault()).getMessage mustBe "Lock held by other process. Cannot ensure lock"
+          }
+        }
+      }
+    }
+  }
+
+  "LockManager on releaseLockDefault" should {
+
+    "call LockRepository" in {
+
+      val lockManager = new LockManager(lockRepository, lockRefreshChecker, timeUtils, config)
+
+      lockManager.releaseLockDefault()
+
+      verify(lockRepository).removeByKeyAndOwner(meq(DefaultKey), any())
+    }
+  }
+
+}

--- a/test/unit/migrations/MigrationsRegistrySpec.scala
+++ b/test/unit/migrations/MigrationsRegistrySpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import com.mongodb.client.MongoDatabase
+import org.scalatest.{MustMatchers, WordSpec}
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+
+class MigrationsRegistrySpec extends WordSpec with MustMatchers {
+
+  private def buildMigrationDefinition(migrationInfo: MigrationInformation): MigrationDefinition = new MigrationDefinition {
+    override val migrationInformation: MigrationInformation = migrationInfo
+    override def migrationFunction(db: MongoDatabase): Unit = {}
+  }
+
+  "MigrationsRegistry on register" should {
+
+    "return new MigrationsRegistry object with MigrationDefinition added" in {
+
+      val migrationDefinition = buildMigrationDefinition(MigrationInformation("id", 0, "author"))
+      val registry = MigrationsRegistry()
+
+      val newRegistry = registry.register(migrationDefinition)
+
+      newRegistry mustNot be(registry)
+      newRegistry.migrations mustNot be(empty)
+      newRegistry.migrations must contain(migrationDefinition)
+    }
+
+    "allow to chain method calls" in {
+
+      val migrationDefinition_1 = buildMigrationDefinition(MigrationInformation("id_1", 1, "author_1"))
+      val migrationDefinition_2 = buildMigrationDefinition(MigrationInformation("id_2", 2, "author_2"))
+      val migrationDefinition_3 = buildMigrationDefinition(MigrationInformation("id_3", 3, "author_3"))
+
+      val registry = MigrationsRegistry().register(migrationDefinition_1).register(migrationDefinition_2).register(migrationDefinition_3)
+
+      registry.migrations.size mustBe 3
+      registry.migrations must contain(migrationDefinition_1)
+      registry.migrations must contain(migrationDefinition_2)
+      registry.migrations must contain(migrationDefinition_3)
+    }
+
+    "allow adding the same MigrationDefinition twice" in {
+
+      val migrationDefinition = buildMigrationDefinition(MigrationInformation("id", 0, "author"))
+
+      val registry = MigrationsRegistry().register(migrationDefinition).register(migrationDefinition)
+
+      registry.migrations.size mustBe 2
+      registry.migrations mustBe Seq(migrationDefinition, migrationDefinition)
+    }
+  }
+
+}

--- a/test/unit/migrations/TimeUtilsSpec.scala
+++ b/test/unit/migrations/TimeUtilsSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations
+
+import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+
+class TimeUtilsSpec extends WordSpec with MustMatchers with MockitoSugar {
+
+  private val timeUtils = new TimeUtils
+
+  "TimeUtils on minutesToMillis" should {
+
+    "correctly convert to milliseconds" in {
+
+      val minutes = 13
+      val expectedOutput = 780000
+
+      timeUtils.minutesToMillis(minutes) mustBe expectedOutput
+    }
+  }
+
+  "TimeUtils on millisToMinutes" should {
+
+    "correctly convert to minutes" in {
+
+      val millis = 120000
+      val expectedOutput = 2
+
+      timeUtils.millisToMinutes(millis) mustBe expectedOutput
+    }
+  }
+
+}

--- a/test/unit/migrations/repositories/ChangeEntryRepositorySpec.scala
+++ b/test/unit/migrations/repositories/ChangeEntryRepositorySpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import com.mongodb.MongoNamespace
+import com.mongodb.client.{FindIterable, MongoCollection, MongoDatabase}
+import org.bson.Document
+import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.exports.migrations.repositories.TestObjectsBuilder.buildMongoCursor
+
+class ChangeEntryRepositorySpec extends WordSpec with MockitoSugar with BeforeAndAfterEach with MustMatchers {
+
+  private val databaseName = "testDatabase"
+  private val collectionName = "testCollection"
+  private val mongoNamespace = new MongoNamespace(databaseName, collectionName)
+
+  private val findIterable = mock[FindIterable[Document]]
+  private val mongoCollection = mock[MongoCollection[Document]]
+  private val mongoDatabase = mock[MongoDatabase]
+
+  private val repo = {
+    defineMocksBehaviourDefault()
+    new ChangeEntryRepository(collectionName, mongoDatabase)
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(findIterable, mongoCollection, mongoDatabase)
+
+    defineMocksBehaviourDefault()
+  }
+
+  override def afterEach(): Unit = {
+    reset(findIterable, mongoCollection, mongoDatabase)
+
+    super.afterEach()
+  }
+
+  private def defineMocksBehaviourDefault(): Unit = {
+    when(mongoCollection.getNamespace).thenReturn(mongoNamespace)
+    when(mongoCollection.find()).thenReturn(findIterable)
+    when(mongoDatabase.getCollection(anyString())).thenReturn(mongoCollection)
+  }
+
+  "ChangeEntryRepository on findAll" should {
+
+    "call MongoCollection" in {
+
+      when(findIterable.iterator()).thenReturn(buildMongoCursor(Seq.empty))
+
+      repo.findAll()
+
+      verify(mongoCollection).find()
+    }
+
+    "return empty List" when {
+      "MongoCollection returned empty Iterable" in {
+
+        when(findIterable.iterator()).thenReturn(buildMongoCursor(Seq.empty))
+
+        val result = repo.findAll()
+
+        result mustBe empty
+      }
+    }
+
+    "return List of Documents returned by MongoCollection" in {
+
+      val elementsInDb = List(new Document("id", "ID_1"), new Document("id", "ID_2"), new Document("id", "ID_3"))
+      when(findIterable.iterator()).thenReturn(buildMongoCursor(elementsInDb))
+
+      val result = repo.findAll()
+
+      result mustBe elementsInDb
+    }
+  }
+
+  "ChangeEntryRepository on save" should {
+
+    "call ChangeEntry" in {
+
+      val changeEntry = mock[ChangeEntry]
+      when(changeEntry.buildFullDBObject).thenReturn(new Document())
+
+      repo.save(changeEntry)
+
+      verify(changeEntry).buildFullDBObject
+    }
+
+    "call MongoCollection" in {
+
+      val changeEntry = mock[ChangeEntry]
+      when(changeEntry.buildFullDBObject).thenReturn(new Document())
+
+      repo.save(changeEntry)
+
+      verify(mongoCollection).insertOne(any[Document])
+    }
+
+    "provide MongoCollection with Document from provided ChangeEntry" in {
+
+      val changeEntry = ChangeEntry("changeIdValue", "authorValue", new Date(), "changeLogClassValue")
+
+      repo.save(changeEntry)
+
+      val expectedDocument = changeEntry.buildFullDBObject
+      verify(mongoCollection).insertOne(meq(expectedDocument))
+    }
+  }
+
+}

--- a/test/unit/migrations/repositories/ChangeEntrySpec.scala
+++ b/test/unit/migrations/repositories/ChangeEntrySpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import org.bson.Document
+import org.scalatest.{MustMatchers, WordSpec}
+
+import scala.collection.JavaConverters.mapAsJavaMap
+
+class ChangeEntrySpec extends WordSpec with MustMatchers {
+
+  "ChangeEntry on buildFullDBObject" should {
+
+    "convert to correct Document" in {
+
+      val date = new Date()
+      val changeEntry = ChangeEntry(changeId = "changeIdValue", author = "authorValue", timestamp = date, changeLogClass = "changeLogClassValue")
+      val expectedOutput =
+        new Document(
+          mapAsJavaMap(Map("changeId" -> "changeIdValue", "author" -> "authorValue", "timestamp" -> date, "changeLogClass" -> "changeLogClassValue"))
+        )
+
+      changeEntry.buildFullDBObject mustBe expectedOutput
+    }
+  }
+}

--- a/test/unit/migrations/repositories/LockEntrySpec.scala
+++ b/test/unit/migrations/repositories/LockEntrySpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import org.bson.Document
+import org.scalatest.{MustMatchers, WordSpec}
+
+import scala.collection.JavaConverters.mapAsJavaMap
+
+class LockEntrySpec extends WordSpec with MustMatchers {
+
+  "LockEntry on buildFullDBObject" should {
+
+    "convert to correct Document" in {
+
+      val date = new Date()
+      val lockEntry = LockEntry(key = "keyValue", status = "statusValue", owner = "ownerValue", expiresAt = date)
+      val expectedOutput =
+        new Document(mapAsJavaMap(Map("key" -> "keyValue", "status" -> "statusValue", "owner" -> "ownerValue", "expiresAt" -> date)))
+
+      lockEntry.buildFullDBObject mustBe expectedOutput
+    }
+  }
+
+}

--- a/test/unit/migrations/repositories/LockRepositorySpec.scala
+++ b/test/unit/migrations/repositories/LockRepositorySpec.scala
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import java.util.Date
+
+import com.mongodb._
+import com.mongodb.client.model.Filters.{and, eq => feq}
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.result.{DeleteResult, UpdateResult}
+import com.mongodb.client.{FindIterable, MongoCollection, MongoDatabase}
+import org.bson.codecs.configuration.CodecRegistries
+import org.bson.codecs.{DateCodec, DocumentCodec, StringCodec}
+import org.bson.conversions.Bson
+import org.bson.{BsonDateTime, BsonDocument, Document}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
+import org.mockito.Mockito._
+import org.mongodb.scala.bson.BsonString
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.exports.migrations.exceptions.LockPersistenceException
+import uk.gov.hmrc.exports.migrations.repositories.LockEntry._
+import uk.gov.hmrc.exports.migrations.repositories.TestObjectsBuilder.buildMongoCursor
+
+import scala.collection.JavaConverters.mapAsJavaMap
+
+class LockRepositorySpec extends WordSpec with MockitoSugar with BeforeAndAfterEach with MustMatchers {
+
+  private val databaseName = "testDatabase"
+  private val collectionName = "testCollection"
+  private val mongoNamespace = new MongoNamespace(databaseName, collectionName)
+
+  private val findIterable = mock[FindIterable[Document]]
+  private val mongoCollection = mock[MongoCollection[Document]]
+  private val mongoDatabase = mock[MongoDatabase]
+
+  private val repo = {
+    defineMocksBehaviourDefault()
+    new LockRepository(collectionName, mongoDatabase)
+  }
+
+  private val lockKey = "lockKeyValue"
+  private val status = LockStatus.LockHeld.name
+  private val owner = "ownerValue"
+  private val date = new Date()
+  private val lockEntry = LockEntry(lockKey, status, owner, date)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(findIterable, mongoCollection, mongoDatabase)
+
+    defineMocksBehaviourDefault()
+  }
+
+  override def afterEach(): Unit = {
+    reset(findIterable, mongoCollection, mongoDatabase)
+
+    super.afterEach()
+  }
+
+  private def defineMocksBehaviourDefault(): Unit = {
+    when(findIterable.iterator()).thenReturn(buildMongoCursor(Seq.empty))
+    when(mongoCollection.getNamespace).thenReturn(mongoNamespace)
+    when(mongoCollection.find(any[Document])).thenReturn(findIterable)
+    when(mongoCollection.deleteMany(any[Document])).thenReturn(DeleteResult.unacknowledged())
+    when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+      .thenReturn(UpdateResult.unacknowledged())
+    when(mongoDatabase.getCollection(anyString())).thenReturn(mongoCollection)
+  }
+
+  private def getDeleteManyFilterQuery: Bson = {
+    val captor: ArgumentCaptor[Bson] = ArgumentCaptor.forClass(classOf[Bson])
+    verify(mongoCollection).deleteMany(captor.capture())
+    captor.getValue
+  }
+
+  private def getUpdateManyFilterQuery: Bson = {
+    val captor: ArgumentCaptor[Bson] = ArgumentCaptor.forClass(classOf[Bson])
+    verify(mongoCollection).updateMany(captor.capture(), any(), any())
+    captor.getValue
+  }
+
+  private def getUpdateManyUpdateQuery: Bson = {
+    val captor: ArgumentCaptor[Bson] = ArgumentCaptor.forClass(classOf[Bson])
+    verify(mongoCollection).updateMany(any(), captor.capture(), any())
+    captor.getValue
+  }
+
+  private def getUpdateManyUpdateOptions: UpdateOptions = {
+    val captor: ArgumentCaptor[UpdateOptions] = ArgumentCaptor.forClass(classOf[UpdateOptions])
+    verify(mongoCollection).updateMany(any(), any(), captor.capture())
+    captor.getValue
+  }
+
+  private def bsonToDocument(bson: Bson) =
+    bson.toBsonDocument(classOf[Document], CodecRegistries.fromCodecs(new DocumentCodec(), new StringCodec(), new DateCodec()))
+
+  "LockRepository on findByKey" should {
+
+    "call MongoCollection" in {
+
+      repo.findByKey("testKey")
+
+      verify(mongoCollection).find(any[Bson])
+    }
+
+    "provide MongoCollection with correct query filter" in {
+
+      repo.findByKey(lockKey)
+
+      val expectedFilter = new Document(KeyField, lockKey)
+      verify(mongoCollection).find(meq(expectedFilter))
+    }
+
+    "return None" when {
+      "MongoCollection returned empty Iterable" in {
+
+        val result = repo.findByKey("testKey")
+
+        result mustBe None
+      }
+    }
+
+    "return LockEntry built from Document returned by MongoCollection" in {
+
+      val elementInDb =
+        new Document(mapAsJavaMap(Map(KeyField -> lockKey, StatusField -> "statusValue", OwnerField -> "ownerValue", ExpiresAtField -> date)))
+      when(findIterable.iterator()).thenReturn(buildMongoCursor(Seq(elementInDb)))
+
+      val result = repo.findByKey(lockKey)
+
+      result mustBe defined
+      val expectedLockEntry = LockEntry(lockKey, "statusValue", "ownerValue", date)
+      result.get mustBe expectedLockEntry
+    }
+  }
+
+  "LockRepository on removeByKeyAndOwner" should {
+
+    "call MongoCollection" in {
+
+      repo.removeByKeyAndOwner("lockKey", "owner")
+
+      verify(mongoCollection).deleteMany(any[Bson])
+    }
+
+    "provide MongoCollection with correct query filter" in {
+
+      repo.removeByKeyAndOwner(lockKey, owner)
+
+      val expectedFilter = bsonToDocument(and(feq(KeyField, lockKey), feq(OwnerField, owner)))
+      val bson = bsonToDocument(getDeleteManyFilterQuery)
+
+      bson.getString(KeyField) mustBe expectedFilter.getString(KeyField)
+      bson.getString(OwnerField) mustBe expectedFilter.getString(OwnerField)
+    }
+  }
+
+  "LockRepository on insertUpdate" should {
+
+    "call MongoCollection" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.insertUpdate(lockEntry)
+
+      verify(mongoCollection).updateMany(any[Bson], any[Bson], any[UpdateOptions])
+    }
+
+    "provide MongoCollection with correct filter query" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.insertUpdate(lockEntry)
+
+      val bson = bsonToDocument(getUpdateManyFilterQuery)
+      bson.getString(KeyField).getValue mustBe lockEntry.key
+      bson.getString(StatusField).getValue mustBe lockEntry.status
+      bson.getArray("$or").get(0).asDocument().getDocument(ExpiresAtField).getDateTime("$lt") mustBe a[BsonDateTime]
+      bson.getArray("$or").get(1).asDocument().getString(OwnerField).getValue mustBe lockEntry.owner
+    }
+
+    "provide MongoCollection with correct update query" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.insertUpdate(lockEntry)
+
+      val actualLockEntry = bsonToDocument(getUpdateManyUpdateQuery).getDocument("$set")
+      actualLockEntry.getString(KeyField).getValue mustBe lockEntry.key
+      actualLockEntry.getString(StatusField).getValue mustBe lockEntry.status
+      actualLockEntry.getString(OwnerField).getValue mustBe lockEntry.owner
+      actualLockEntry.getDateTime(ExpiresAtField) mustBe a[BsonDateTime]
+    }
+
+    "provide MongoCollection with correct UpdateOptions" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.insertUpdate(lockEntry)
+
+      val actualUpdateOptions = getUpdateManyUpdateOptions
+      actualUpdateOptions.isUpsert mustBe true
+    }
+
+    "throw LockPersistenceException" when {
+
+      "MongoCollection throws DuplicateKeyException" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenThrow(new DuplicateKeyException(new BsonDocument(), new ServerAddress(), WriteConcernResult.unacknowledged()))
+
+        intercept[LockPersistenceException](repo.insertUpdate(lockEntry)).getMessage mustBe "Lock is held"
+      }
+
+      "MongoCollection throws MongoWriteException with error category Duplicate Key" in {
+
+        val duplicateKeyErrorCode = 11000
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenThrow(new MongoWriteException(new WriteError(duplicateKeyErrorCode, "", new BsonDocument()), new ServerAddress()))
+
+        intercept[LockPersistenceException](repo.insertUpdate(lockEntry)).getMessage mustBe "Lock is held"
+      }
+
+      "MongoCollection returns UpdateResult with ModifiedCount == 0 and UpsertedId == null" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenReturn(UpdateResult.acknowledged(1, 0L, null))
+
+        intercept[LockPersistenceException](repo.insertUpdate(lockEntry)).getMessage mustBe "Lock is held"
+      }
+    }
+
+    "throw MongoWriteException" when {
+
+      "MongoCollection throws MongoWriteException with error category other than Duplicate Key" in {
+
+        val UncategorizedErrorCode = 12345
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenThrow(new MongoWriteException(new WriteError(UncategorizedErrorCode, "", new BsonDocument()), new ServerAddress()))
+
+        intercept[MongoWriteException](repo.insertUpdate(lockEntry))
+      }
+    }
+
+    "not throw LockPersistenceException" when {
+
+      "MongoCollection returns UpdateResult with ModifiedCount == 0 and defined UpsertedId" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenReturn(UpdateResult.acknowledged(1, 0L, BsonString("UpsertedId")))
+
+        noException mustBe thrownBy(repo.insertUpdate(lockEntry))
+      }
+
+      "MongoCollection returns UpdateResult with ModifiedCount other than 0 and UpsertedId == null" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenReturn(UpdateResult.acknowledged(1, 1L, null))
+
+        noException mustBe thrownBy(repo.insertUpdate(lockEntry))
+      }
+    }
+  }
+
+  "LockRepository on updateIfSameOwner" should {
+
+    "call MongoCollection" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.updateIfSameOwner(lockEntry)
+
+      verify(mongoCollection).updateMany(any[Bson], any[Bson], any[UpdateOptions])
+    }
+
+    "provide MongoCollection with correct filter query" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.updateIfSameOwner(lockEntry)
+
+      val bson = bsonToDocument(getUpdateManyFilterQuery)
+      bson.getString(KeyField).getValue mustBe lockEntry.key
+      bson.getString(StatusField).getValue mustBe lockEntry.status
+      bson.getArray("$or").get(0).asDocument().getString(OwnerField).getValue mustBe lockEntry.owner
+    }
+
+    "provide MongoCollection with correct update query" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.updateIfSameOwner(lockEntry)
+
+      val actualLockEntry = bsonToDocument(getUpdateManyUpdateQuery).getDocument("$set")
+      actualLockEntry.getString(KeyField).getValue mustBe lockEntry.key
+      actualLockEntry.getString(StatusField).getValue mustBe lockEntry.status
+      actualLockEntry.getString(OwnerField).getValue mustBe lockEntry.owner
+      actualLockEntry.getDateTime(ExpiresAtField) mustBe a[BsonDateTime]
+    }
+
+    "provide MongoCollection with correct UpdateOptions" in {
+
+      when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+        .thenReturn(UpdateResult.acknowledged(1, 1L, BsonString("UpsertedId")))
+
+      repo.updateIfSameOwner(lockEntry)
+
+      val actualUpdateOptions = getUpdateManyUpdateOptions
+      actualUpdateOptions.isUpsert mustBe false
+    }
+
+    "throw LockPersistenceException" when {
+
+      "MongoCollection throws DuplicateKeyException" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenThrow(new DuplicateKeyException(new BsonDocument(), new ServerAddress(), WriteConcernResult.unacknowledged()))
+
+        intercept[LockPersistenceException](repo.updateIfSameOwner(lockEntry)).getMessage mustBe "Lock is held"
+      }
+
+      "MongoCollection throws MongoWriteException with error category Duplicate Key" in {
+
+        val duplicateKeyErrorCode = 11000
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenThrow(new MongoWriteException(new WriteError(duplicateKeyErrorCode, "", new BsonDocument()), new ServerAddress()))
+
+        intercept[LockPersistenceException](repo.updateIfSameOwner(lockEntry)).getMessage mustBe "Lock is held"
+      }
+
+      "MongoCollection returns UpdateResult with ModifiedCount == 0 and UpsertedId == null" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenReturn(UpdateResult.acknowledged(1, 0L, null))
+
+        intercept[LockPersistenceException](repo.updateIfSameOwner(lockEntry)).getMessage mustBe "Lock is held"
+      }
+    }
+
+    "throw MongoWriteException" when {
+
+      "MongoCollection throws MongoWriteException with error category other than Duplicate Key" in {
+
+        val UncategorizedErrorCode = 12345
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenThrow(new MongoWriteException(new WriteError(UncategorizedErrorCode, "", new BsonDocument()), new ServerAddress()))
+
+        intercept[MongoWriteException](repo.updateIfSameOwner(lockEntry))
+      }
+    }
+
+    "not throw LockPersistenceException" when {
+
+      "MongoCollection returns UpdateResult with ModifiedCount == 0 and defined UpsertedId" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenReturn(UpdateResult.acknowledged(1, 0L, BsonString("UpsertedId")))
+
+        noException mustBe thrownBy(repo.updateIfSameOwner(lockEntry))
+      }
+
+      "MongoCollection returns UpdateResult with ModifiedCount other than 0 and UpsertedId == null" in {
+
+        when(mongoCollection.updateMany(any[Document], any[Document], any[UpdateOptions]))
+          .thenReturn(UpdateResult.acknowledged(1, 1L, null))
+
+        noException mustBe thrownBy(repo.updateIfSameOwner(lockEntry))
+      }
+    }
+  }
+}

--- a/test/unit/migrations/repositories/MongoRepositorySpec.scala
+++ b/test/unit/migrations/repositories/MongoRepositorySpec.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import com.mongodb.MongoNamespace
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.{ListIndexesIterable, MongoCollection, MongoDatabase}
+import org.bson.Document
+import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfterEach, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.Json
+import uk.gov.hmrc.exports.migrations.repositories.TestObjectsBuilder.buildMongoCursor
+
+import scala.collection.JavaConverters._
+
+class MongoRepositorySpec extends WordSpec with MockitoSugar with BeforeAndAfterEach {
+
+  private val databaseName = "testDatabase"
+  private val collectionName = "testCollection"
+  private val mongoNamespace = new MongoNamespace(databaseName, collectionName)
+  private val testIndex = "TestIndex"
+
+  private val indexesList = mock[ListIndexesIterable[Document]]
+  private val mongoCollection = mock[MongoCollection[Document]]
+  private val mongoDatabase = mock[MongoDatabase]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(indexesList, mongoCollection, mongoDatabase)
+
+    when(mongoCollection.getNamespace).thenReturn(mongoNamespace)
+    when(mongoCollection.createIndex(any(), any())).thenReturn(testIndex)
+    when(mongoCollection.listIndexes).thenReturn(indexesList)
+    when(mongoDatabase.getCollection(anyString())).thenReturn(mongoCollection)
+  }
+
+  override def afterEach(): Unit = {
+    reset(indexesList, mongoCollection, mongoDatabase)
+
+    super.afterEach()
+  }
+
+  private def buildIndex(field: String): Document = {
+    val fields = Map("key" -> new Document(field, 1), "name" -> s"${field}Name")
+    new Document(mapAsJavaMap(fields))
+  }
+
+  private def buildUniqueIndex(field: String): Document = {
+    val fields =
+      Json.obj("key" -> Json.obj(field -> 1), "name" -> s"${field}Name", "ns" -> (databaseName + "." + collectionName), "unique" -> true).toString()
+
+    Document.parse(fields)
+  }
+
+  "MongoRepository on ensureIndex" when {
+
+    "there is no index in DB" should {
+
+      "call MongoCollection to create index" in {
+
+        when(indexesList.iterator()).thenReturn(buildMongoCursor(Seq.empty))
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array("uniqueIndex")) {}
+
+        repo.ensureIndex()
+
+        verify(mongoCollection).createIndex(meq(new Document("uniqueIndex", 1)), any[IndexOptions])
+      }
+    }
+
+    "there is non-unique index in DB" should {
+
+      "call MongoCollection to drop index" in {
+
+        val mongoCursor = buildMongoCursor(Seq(buildIndex("DEFAULT_LOCK")))
+        when(indexesList.iterator()).thenReturn(mongoCursor)
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array("uniqueIndex")) {}
+
+        repo.ensureIndex()
+
+        verify(mongoCollection).dropIndex(anyString())
+      }
+
+      "call MongoCollection to create index" in {
+
+        val mongoCursor = buildMongoCursor(Seq(buildIndex("DEFAULT_LOCK")))
+        when(indexesList.iterator()).thenReturn(mongoCursor)
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array("uniqueIndex")) {}
+
+        repo.ensureIndex()
+
+        verify(mongoCollection).createIndex(meq(new Document("uniqueIndex", 1)), any[IndexOptions])
+      }
+    }
+
+    "there is unique index in DB" should {
+
+      val uniqueField = "uniqueIndex"
+
+      "not call MongoCollection to drop or create index" in {
+
+        val mongoCursor = buildMongoCursor(Seq(buildUniqueIndex(uniqueField)))
+        when(indexesList.iterator()).thenReturn(mongoCursor)
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array(uniqueField)) {}
+
+        repo.ensureIndex()
+
+        verify(mongoCollection, never()).dropIndex(anyString())
+        verify(mongoCollection, never()).createIndex(any[Document], any[IndexOptions])
+      }
+    }
+
+    "there are both unique and non-unique indexes in DB" should {
+
+      val uniqueField = "uniqueIndex"
+
+      "call MongoCollection to drop all non-unique indexes" in {
+
+        val mongoCursor =
+          buildMongoCursor(Seq(buildUniqueIndex(uniqueField), buildIndex("DEFAULT_LOCK"), buildIndex("DEFAULT_LOCK_2")))
+        when(indexesList.iterator()).thenReturn(mongoCursor)
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array(uniqueField)) {}
+
+        repo.ensureIndex()
+
+        verify(mongoCollection).dropIndex(meq("DEFAULT_LOCKName"))
+        verify(mongoCollection).dropIndex(meq("DEFAULT_LOCK_2Name"))
+      }
+
+      "not call MongoCollection to create index qwerty" in {
+
+        val mongoCursor =
+          buildMongoCursor(Seq(buildUniqueIndex(uniqueField), buildIndex("DEFAULT_LOCK"), buildIndex("DEFAULT_LOCK_2")))
+        when(indexesList.iterator()).thenReturn(mongoCursor)
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array(uniqueField)) {}
+
+        repo.ensureIndex()
+
+        verify(mongoCollection, never()).createIndex(any[Document], any[IndexOptions])
+      }
+    }
+
+    "called twice" should {
+
+      "not call MongoCollection again" in {
+
+        when(indexesList.iterator()).thenReturn(buildMongoCursor(Seq.empty))
+        val repo = new MongoRepository(mongoDatabase, collectionName, Array("uniqueIndex")) {}
+
+        repo.ensureIndex()
+        repo.ensureIndex()
+
+        verify(mongoCollection, atMostOnce()).createIndex(meq(new Document("uniqueIndex", 1)), any[IndexOptions])
+      }
+    }
+  }
+
+}

--- a/test/unit/migrations/repositories/TestObjectsBuilder.scala
+++ b/test/unit/migrations/repositories/TestObjectsBuilder.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.repositories
+
+import com.mongodb.client.MongoCursor
+import com.mongodb.{ServerAddress, ServerCursor}
+import org.bson.Document
+
+object TestObjectsBuilder {
+
+  /**
+    * Creates a dummy MongoCursor for testing purposes.
+    *
+    * Some of the methods are missing implementation, because they are not used in tests yet.
+    * Only the iterative part of the MongoCursor is being used for now.
+    *
+    * @param elements sequence of Document objects to be iterated over
+    * @return MongoCursor
+    */
+  def buildMongoCursor(elements: Seq[Document]): MongoCursor[Document] = new MongoCursor[Document] {
+    private val iterator = elements.iterator
+
+    override def close(): Unit = ???
+    override def hasNext: Boolean = iterator.hasNext
+    override def next(): Document = iterator.next
+    override def tryNext(): Document = ???
+    override def getServerCursor: ServerCursor = ???
+    override def getServerAddress: ServerAddress = ???
+  }
+}


### PR DESCRIPTION
Adding a db migration feature that runs on application
startup as a precursor to making certain fields of the
Notification entity optional.

No migrations are included in this commit (will be
added later)