### PR TITLE
CEDS-2897 update deprecated config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -63,10 +63,9 @@ application.session.httpOnly=false
 application.session.secure=false
 
 # The application languages
-application.langs="en"
 
 # Router
-application.router=prod.Routes
+play.http.router=prod.Routes
 
 json.encryption {
     key="eTRDaFlxN01vM3BiUHhtNw=="


### PR DESCRIPTION
application.langs now deprecated, play.i18n.langs is provided with english language by default by the bootstrap libraries. 

See [blogpost](https://confluence.tools.tax.service.gov.uk/display/TEC/2020/12/01/Cleanup+deprecated+Play+framework+configuration+keys)