### PR TITLE
[CEDS-2786] Implement asynchronous notifications processing

### DIFF
--- a/app/controllers/notifications/NotificationCallbackController.scala
+++ b/app/controllers/notifications/NotificationCallbackController.scala
@@ -38,7 +38,7 @@ class NotificationCallbackController @Inject()(notificationsService: Notificatio
     val timer = metrics.startTimer(notificationMetric)
     val notification = req.body
 
-    notificationsService.save(notification).map {
+    notificationsService.parseAndSave(notification).map {
       case Right(_) =>
         timer.stop()
         metrics.incrementCounter(notificationMetric)

--- a/app/controllers/notifications/NotificationController.scala
+++ b/app/controllers/notifications/NotificationController.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.NotificationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import models.Notification.FrontendFormat._
 
 import scala.concurrent.ExecutionContext
 
@@ -31,7 +32,7 @@ class NotificationController @Inject()(authorise: AuthAction, notificationServic
 ) extends BackendController(cc) {
 
   def getNotification(reference: String): Action[AnyContent] = authorise.async {
-    notificationService.findNotificationByReference(reference).map {
+    notificationService.getNotificationForReference(reference).map {
       case Some(notification) => Ok(Json.toJson(notification))
       case None               => NotFound
     }

--- a/app/migrations/ExportsMigrationTool.scala
+++ b/app/migrations/ExportsMigrationTool.scala
@@ -69,6 +69,9 @@ class ExportsMigrationTool(
           }
           logger.warn(lockEx.getMessage)
           logger.warn("ExportsMigrationTool did not acquire process lock. EXITING WITHOUT RUNNING DATA MIGRATION")
+
+        case exc: Throwable =>
+          logger.error("ExportsMigrationTool - error on executing migration", exc)
       } finally {
         lockManager.releaseLockDefault() //we do it anyway, it's idempotent
 
@@ -105,7 +108,7 @@ class ExportsMigrationTool(
       }
 
     } catch {
-      case exc: ExportsMigrationException => logger.error(exc.getMessage)
+      case exc: ExportsMigrationException => logger.error(s"Error while executing '${migrDefinition.migrationInformation}' ${exc.getMessage}")
     }
   }
 

--- a/app/migrations/MigrationRoutine.scala
+++ b/app/migrations/MigrationRoutine.scala
@@ -20,6 +20,7 @@ import com.google.inject.Singleton
 import com.mongodb.{MongoClient, MongoClientURI}
 import config.AppConfig
 import javax.inject.Inject
+import migrations.changelogs.notification.MakeParsedDetailsOptional
 import play.api.Logger
 import uk.gov.hmrc.exports.routines.{Routine, RoutinesExecutionContext}
 
@@ -42,6 +43,7 @@ class MigrationRoutine @Inject()(appConfig: AppConfig)(implicit mec: RoutinesExe
   private def migrateWithExportsMigrationTool(): Unit = {
     val lockManagerConfig = LockManagerConfig(lockMaxTries = 10, lockMaxWaitMillis = minutesToMillis(5), lockAcquiredForMillis = minutesToMillis(3))
     val migrationsRegistry = MigrationsRegistry()
+      .register(new MakeParsedDetailsOptional())
     val migrationTool = ExportsMigrationTool(db, migrationsRegistry, lockManagerConfig)
 
     migrationTool.execute()

--- a/app/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
+++ b/app/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations.changelogs.notification
+
+import com.mongodb.client.MongoDatabase
+import org.bson.Document
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Filters.{and, exists, or, eq => feq}
+import org.mongodb.scala.model.UpdateOneModel
+import org.mongodb.scala.model.Updates.{combine, set, unset}
+import play.api.Logger
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+
+import scala.collection.JavaConverters._
+
+class MakeParsedDetailsOptional extends MigrationDefinition {
+
+  private val logger = Logger(this.getClass)
+
+  private val INDEX_ID = "_id"
+  private val FILEREF = "fileReference"
+  private val OUTCOME = "outcome"
+  private val FILENAME = "filename"
+  private val DETAILS = "details"
+  private val PAYLOAD = "payload"
+
+  private val DEFAULT_PAYLOAD_VALUE = "N/A"
+
+  private val collectionName = "notifications"
+
+  override val migrationInformation: MigrationInformation =
+    MigrationInformation(
+      id = "CEDS-2786 Make the parsed detail fields fileReference, outcome and filename optional",
+      order = 1,
+      author = "Tim Wilkins",
+      runAlways = true
+    )
+
+  override def migrationFunction(db: MongoDatabase): Unit = {
+
+    logger.info(s"Applying '${migrationInformation.id}' db migration...")
+
+    val query = or(exists(FILEREF), exists(OUTCOME), exists(FILENAME))
+    val queryBatchSize = 10
+    val updateBatchSize = 100
+
+    def createDetailsSubDoc(document: Document) = {
+      val fileReference = document.get(FILEREF).asInstanceOf[String]
+      val outcome = document.get(OUTCOME).asInstanceOf[String]
+      val filename = document.get(FILENAME).asInstanceOf[String]
+
+      new Document()
+        .append(FILEREF, fileReference)
+        .append(OUTCOME, outcome)
+        .append(FILENAME, filename)
+    }
+
+    val collection = db.getCollection(collectionName)
+
+    val redundantIndexesToBeDeleted = Vector("fileReferenceIndex")
+    collection.listIndexes().iterator().forEachRemaining { idx =>
+      val indexName = idx.getString("name")
+      if (redundantIndexesToBeDeleted.contains(indexName))
+        collection.dropIndex(indexName)
+    }
+
+    getDocumentsToUpdate(db, query, queryBatchSize).map { document =>
+      val documentId = document.get(INDEX_ID)
+
+      val detailsSubDoc = createDetailsSubDoc(document)
+      logger.info(s"Creating new sub-document: $detailsSubDoc for documentId=$documentId")
+
+      val filter = and(feq(INDEX_ID, documentId))
+      val update = combine(unset(FILEREF), unset(OUTCOME), unset(FILENAME), set(PAYLOAD, DEFAULT_PAYLOAD_VALUE), set(DETAILS, detailsSubDoc))
+      logger.info(s"[filter: $filter] [update: $update]")
+
+      new UpdateOneModel[Document](filter, update)
+    }.grouped(updateBatchSize).zipWithIndex.foreach {
+      case (requests, idx) =>
+        logger.info(s"Updating batch no. $idx...")
+
+        collection.bulkWrite(seqAsJavaList(requests))
+        logger.info(s"Updated batch no. $idx")
+    }
+
+    logger.info(s"Applying '${migrationInformation.id}' db migration... Done.")
+  }
+
+  private def getDocumentsToUpdate(db: MongoDatabase, filter: Bson, queryBatchSize: Int) =
+    asScalaIterator(
+      db.getCollection(collectionName)
+        .find(filter)
+        .batchSize(queryBatchSize)
+        .iterator
+    )
+}

--- a/app/models/Notification.scala
+++ b/app/models/Notification.scala
@@ -17,12 +17,50 @@
 package models
 
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
-case class Notification(fileReference: String, outcome: String, filename: String, createdAt: DateTime = DateTime.now.withZone(DateTimeZone.UTC))
+case class NotificationDetails(fileReference: String, outcome: String, filename: String)
+
+object NotificationDetails {
+  implicit val writes: OWrites[NotificationDetails] = Json.writes[NotificationDetails]
+  implicit val reads: Reads[NotificationDetails] =
+    ((__ \ "fileReference").read[String] and
+      (__ \ "outcome").read[String] and
+      (__ \ "filename").read[String])(NotificationDetails.apply _)
+
+  implicit val format: Format[NotificationDetails] = Format(reads, writes)
+}
+
+case class Notification(
+  _id: BSONObjectID,
+  payload: String,
+  details: Option[NotificationDetails] = None,
+  createdAt: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
+)
 
 object Notification {
-  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
-  implicit val notificationFormat = Json.format[Notification]
+  object DbFormat extends ReactiveMongoFormats {
+    implicit val notificationFormat: OFormat[Notification] = Json.format[Notification]
+  }
+
+  object FrontendFormat {
+    implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
+
+    def writes(notification: Notification) =
+      notification.details.map { details =>
+        Json.obj(
+          "fileReference" -> details.fileReference,
+          "outcome" -> details.outcome,
+          "filename" -> details.filename,
+          "createdAt" -> notification.createdAt
+        )
+      }.getOrElse {
+        Json.obj("fileReference" -> "", "outcome" -> "", "filename" -> "", "createdAt" -> notification.createdAt)
+      }
+
+    implicit val notificationsWrites: Writes[Notification] = writes
+  }
 }

--- a/app/routines/ReattemptNotificationParsingRoutine.scala
+++ b/app/routines/ReattemptNotificationParsingRoutine.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routines
+
+import javax.inject.Inject
+import play.api.Logger
+import services.NotificationService
+import uk.gov.hmrc.exports.routines.{Routine, RoutinesExecutionContext}
+
+import scala.concurrent.Future
+
+class ReattemptNotificationParsingRoutine @Inject()(notificationService: NotificationService)(implicit mec: RoutinesExecutionContext)
+    extends Routine {
+  private val logger = Logger(this.getClass)
+
+  def execute(): Future[Unit] = {
+    logger.info("Starting NotificationService.reattemptParsingUnparsedNotifications()...")
+    notificationService
+      .reattemptParsingUnparsedNotifications()
+      .map { _ =>
+        logger.info("Finished NotificationService.reattemptParsingUnparsedNotifications()")
+      }
+  }
+}

--- a/app/routines/RoutineRunner.scala
+++ b/app/routines/RoutineRunner.scala
@@ -19,18 +19,23 @@ package uk.gov.hmrc.exports.routines
 import akka.actor.{ActorSystem, Cancellable}
 import javax.inject.Inject
 import play.api.inject.ApplicationLifecycle
+import routines.ReattemptNotificationParsingRoutine
 import uk.gov.hmrc.exports.migrations.MigrationRoutine
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class RoutineRunner @Inject()(migrationRunner: MigrationRoutine, actorSystem: ActorSystem, applicationLifecycle: ApplicationLifecycle)(
-  implicit mec: RoutinesExecutionContext
-) {
+class RoutineRunner @Inject()(
+  migrationRunner: MigrationRoutine,
+  reattemptParsing: ReattemptNotificationParsingRoutine,
+  actorSystem: ActorSystem,
+  applicationLifecycle: ApplicationLifecycle
+)(implicit mec: RoutinesExecutionContext) {
 
   val migrationTask: Cancellable = actorSystem.scheduler.scheduleOnce(0.seconds) {
     for {
       _ <- migrationRunner.execute()
+      _ <- reattemptParsing.execute()
     } yield (())
   }
 

--- a/test/it/base/IntegrationSpec.scala
+++ b/test/it/base/IntegrationSpec.scala
@@ -9,6 +9,11 @@ import scala.reflect.ClassTag
 
 trait IntegrationSpec extends WordSpec with MustMatchers with ScalaFutures with IntegrationPatience with OptionValues {
 
+  val Port = 27017
+  val DatabaseName = "test-cds-file-upload"
+  val MongoURI = s"mongodb://localhost:$Port/$DatabaseName"
+  val CollectionName = "notifications"
+
   /**
     * Builder which provides test database for the service to not use the main one.
     */
@@ -16,7 +21,7 @@ trait IntegrationSpec extends WordSpec with MustMatchers with ScalaFutures with 
     new GuiceApplicationBuilder()
       .overrides(modules: _*)
       .configure(config: _*)
-      .configure(("mongodb.uri", "mongodb://localhost:27017/test-cds-file-upload"))
+      .configure(("mongodb.uri", MongoURI))
 
   def testApp: Application = builderWithTestMongo(Seq.empty).build()
 

--- a/test/it/migrations/changelogs/notification/MakeParsedDetailsOptionalIntegrationSpec.scala
+++ b/test/it/migrations/changelogs/notification/MakeParsedDetailsOptionalIntegrationSpec.scala
@@ -1,0 +1,116 @@
+package migrations.changelogs.notification
+
+import base.IntegrationSpec
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mongodb.{MongoClient, MongoClientURI}
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+import com.mongodb.client.model.Indexes
+import migrations.changelogs.notification.MakeParsedDetailsOptionalIntegrationSpec._
+import org.bson.Document
+import org.mongodb.scala.model.IndexOptions
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+
+class MakeParsedDetailsOptionalIntegrationSpec extends IntegrationSpec with GuiceOneServerPerSuite with BeforeAndAfterEach {
+
+  override def fakeApplication(): Application = testApp
+
+  private implicit val mongoDatabase: MongoDatabase = {
+    val uri = new MongoClientURI(MongoURI.replaceAllLiterally("sslEnabled", "ssl"))
+    val client = new MongoClient(uri)
+
+    client.getDatabase(DatabaseName)
+  }
+
+  private val changeLog = new MakeParsedDetailsOptional()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    mongoDatabase.getCollection(CollectionName).drop()
+  }
+
+  override def afterEach(): Unit = {
+    mongoDatabase.getCollection(CollectionName).drop()
+    super.afterEach()
+  }
+
+  private def getDeclarationsCollection(db: MongoDatabase): MongoCollection[Document] = mongoDatabase.getCollection(CollectionName)
+
+  "MakeParsedDetailsOptional migration definition" should {
+
+    "correctly migrate records from previous format" in {
+      runTest(testDataBeforeChangeSet_1, testDataAfterChangeSet_1)(changeLog.migrationFunction)
+    }
+
+    "not change records already migrated" in {
+      runTest(testDataAfterChangeSet_1, testDataAfterChangeSet_1)(changeLog.migrationFunction)
+    }
+
+    "not change records that were not yet parsed" in {
+      runTest(testDataUnparsableNotification, testDataUnparsableNotification)(changeLog.migrationFunction)
+    }
+
+    "drop the decommissioned index" in {
+      val collection = getDeclarationsCollection(mongoDatabase)
+      collection.createIndex(Indexes.ascending("fileReference"), IndexOptions().name("fileReferenceIndex"))
+
+      runTest(testDataBeforeChangeSet_1, testDataAfterChangeSet_1)(changeLog.migrationFunction)
+
+      val indexesToBeDeleted = Vector("fileReferenceIndex")
+      collection.listIndexes().iterator().forEachRemaining { idx =>
+        indexesToBeDeleted.contains(idx.getString("name")) mustBe false
+      }
+    }
+  }
+
+  private def runTest(inputDataJson: String, expectedDataJson: String)(test: MongoDatabase => Unit)(implicit mongoDatabase: MongoDatabase): Unit = {
+    getDeclarationsCollection(mongoDatabase).insertOne(Document.parse(inputDataJson))
+
+    test(mongoDatabase)
+
+    val result: Document = getDeclarationsCollection(mongoDatabase).find().first()
+    val expectedResult: String = expectedDataJson
+
+    compareJson(result.toJson, expectedResult)
+  }
+
+  private def compareJson(actual: String, expected: String): Unit = {
+    val mapper = new ObjectMapper
+
+    val jsonActual = mapper.readTree(actual)
+    val jsonExpected = mapper.readTree(expected)
+
+    jsonActual mustBe jsonExpected
+  }
+}
+
+object MakeParsedDetailsOptionalIntegrationSpec {
+  val testDataBeforeChangeSet_1: String =
+    """{
+      |    "_id" : "5fcfa669474b993df8c3058e",
+      |    "fileReference" : "3",
+      |    "outcome" : "SUCCESS",
+      |    "filename" : "File_3.pdf",
+      |    "createdAt" : "2020-12-08T16:14:33.043Z"
+      |}""".stripMargin
+
+  val testDataAfterChangeSet_1: String =
+    """{
+      |    "_id" : "5fcfa669474b993df8c3058e",
+      |    "payload" : "N/A",
+      |    "details" : {
+      |        "fileReference" : "3",
+      |        "outcome" : "SUCCESS",
+      |        "filename" : "File_3.pdf"
+      |    },
+      |    "createdAt" : "2020-12-08T16:14:33.043Z"
+      |}""".stripMargin
+
+  val testDataUnparsableNotification: String =
+    """{
+      |    "_id" : "5fcfa75a474b993df8c309d7",
+      |    "payload" : "<Root><FileReference>3</FileReference><BatchId>5e634e09-77f6-4ff1-b92a-8a9676c715c4</BatchId><FileName>File_3.pdf</FileName><Outcome>SUCCESS</Outcome><Details>[detail block]</Details></Root>",
+      |    "createdAt" : "2020-12-08T16:18:34.328Z"
+      |}""".stripMargin
+}

--- a/test/it/repositories/NotificationsRepositoryIntegrationSpec.scala
+++ b/test/it/repositories/NotificationsRepositoryIntegrationSpec.scala
@@ -1,15 +1,21 @@
 package repositories
 
 import base.IntegrationSpec
-import models.Notification
+import base.TestData._
+import models.{Notification, NotificationDetails}
 import org.scalatest.BeforeAndAfterEach
 import reactivemongo.api.indexes.IndexType
+import reactivemongo.bson.BSONObjectID
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class NotificationsRepositoryIntegrationSpec extends IntegrationSpec with BeforeAndAfterEach {
 
-  private val exampleNotification = Notification("FileReference", "outcome", "filename")
+  private val exampleParsedNotification =
+    Notification(BSONObjectID.generate(), payload, Some(NotificationDetails(fileReference, outcomeSuccess, filename)), dateTime)
+
+  private val exampleUnparsedNotification =
+    Notification(BSONObjectID.generate(), payload, None, dateTime)
 
   private val notificationsRepository = instanceOfWithTestDb[NotificationsRepository]
 
@@ -23,35 +29,106 @@ class NotificationsRepositoryIntegrationSpec extends IntegrationSpec with Before
 
     "have correct indexes" in {
 
-      val Seq(firstIndex, secondIndex) = notificationsRepository.indexes
+      val Seq(firstIndex, secondIndex, thirdIndex) = notificationsRepository.indexes
 
-      firstIndex.key mustBe Seq(("fileReference", IndexType.Ascending))
-      firstIndex.name.value mustBe "fileReferenceIndex"
+      firstIndex.key mustBe Seq(("details.fileReference", IndexType.Ascending))
+      firstIndex.name.value mustBe "detailsFileReferenceIdx"
 
       secondIndex.key mustBe Seq(("createdAt", IndexType.Ascending))
       secondIndex.name.value mustBe "createdAtIndex"
+
+      thirdIndex.key mustBe Seq(("details", IndexType.Ascending))
+      thirdIndex.name.value mustBe "detailsMissingIdx"
+    }
+  }
+
+  "Notification repository save operation" should {
+    "successfully save a parsed notification" in {
+      notificationsRepository.save(exampleParsedNotification).futureValue mustBe Right(())
+
+      val result = notificationsRepository.findAll().futureValue
+
+      result.size must equal(1)
+      result.head must equal(exampleParsedNotification)
     }
 
-    "return empty list" when {
+    "successfully save an unparsed notification" in {
+      notificationsRepository.save(exampleUnparsedNotification).futureValue mustBe Right(())
 
-      "there is no notifications in the database" in {
+      val result = notificationsRepository.findAll().futureValue
 
-        val result = notificationsRepository.findAll().futureValue
+      result.size must equal(1)
+      result.head must equal(exampleUnparsedNotification)
+    }
+  }
 
-        result mustBe empty
-      }
+  "Notification Repository on findNotificationsByReference" should {
+    val sampleRef = exampleParsedNotification.details.get.fileReference
+
+    "there are no Notifications for the given reference" in {
+      notificationsRepository.findNotificationsByReference(sampleRef).futureValue must equal(Seq.empty)
     }
 
-    "return saved notification" when {
+    "there is a single Notification for the given reference" in {
+      notificationsRepository.save(exampleParsedNotification).futureValue mustBe Right(())
 
-      "database contains notification" in {
+      val foundNotifications = notificationsRepository.findNotificationsByReference(sampleRef).futureValue
 
-        notificationsRepository.insert(exampleNotification).futureValue
+      foundNotifications.length must equal(1)
+      foundNotifications.head must equal(exampleParsedNotification)
+    }
 
-        val result = notificationsRepository.findAll().futureValue
+    "there are multiple Notifications for the given reference" in {
+      val anotherMatchingNotification = exampleParsedNotification.copy(_id = BSONObjectID.generate())
 
-        result mustBe List(exampleNotification)
-      }
+      notificationsRepository.save(exampleParsedNotification).futureValue mustBe Right(())
+      notificationsRepository.save(anotherMatchingNotification).futureValue mustBe Right(())
+      notificationsRepository.save(exampleUnparsedNotification).futureValue mustBe Right(())
+
+      val foundNotifications = notificationsRepository.findNotificationsByReference(sampleRef).futureValue
+
+      foundNotifications.length must equal(2)
+    }
+  }
+
+  "Notification Repository on findUnparsedNotifications" should {
+    "there are no Notifications that have not been parsed" in {
+      notificationsRepository.findUnparsedNotifications().futureValue must equal(Seq.empty)
+    }
+
+    "there is a single Notification that have not been parsed" in {
+      notificationsRepository.save(exampleUnparsedNotification).futureValue mustBe Right(())
+
+      val foundNotifications = notificationsRepository.findUnparsedNotifications().futureValue
+
+      foundNotifications.length must equal(1)
+      foundNotifications.head must equal(exampleUnparsedNotification)
+    }
+
+    "there are multiple Notifications that have not been parsed" in {
+      val anotherUnparsedNotification = exampleUnparsedNotification.copy(_id = BSONObjectID.generate())
+
+      notificationsRepository.save(exampleUnparsedNotification).futureValue mustBe Right(())
+      notificationsRepository.save(anotherUnparsedNotification).futureValue mustBe Right(())
+
+      val foundNotifications = notificationsRepository.findUnparsedNotifications().futureValue
+
+      foundNotifications.length must equal(2)
+    }
+  }
+
+  "Notification Repository on updateNotification" should {
+    "update the notification with the same _id" in {
+      notificationsRepository.save(exampleUnparsedNotification).futureValue mustBe Right(())
+
+      val modified = exampleUnparsedNotification.copy(details = exampleParsedNotification.details.map(_.copy(filename = "NEW.txt")))
+
+      notificationsRepository.updateNotification(modified).futureValue
+
+      val result = notificationsRepository.findNotificationsByReference(modified.details.get.fileReference).futureValue
+
+      result.size must equal(1)
+      result.head mustBe modified
     }
   }
 }

--- a/test/unit/base/TestData.scala
+++ b/test/unit/base/TestData.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import org.joda.time.{DateTime, DateTimeZone}
+
+object TestData {
+  val fileReference = "e4d94295-52b1-4837-bdc0-7ab8d7b0f1af"
+  val outcomeSuccess = "SUCCESS"
+  val filename = "sample.pdf"
+  val payload = "<xml></xml>"
+  val dateTime: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
+  val batchId = "5e634e09-77f6-4ff1-b92a-8a9676c715c4"
+
+  def getNotificationXml(fileReference: String, outcome: String, filename: String, batchId: String) =
+    <Root>
+      <FileReference>{fileReference}</FileReference>
+      <BatchId>{batchId}</BatchId>
+      <FileName>{filename}</FileName>
+      <Outcome>{outcome}</Outcome>
+      <Details>[detail block]</Details>
+    </Root>
+}

--- a/test/unit/controllers/notifications/NotificationCallbackControllerSpec.scala
+++ b/test/unit/controllers/notifications/NotificationCallbackControllerSpec.scala
@@ -47,7 +47,7 @@ class NotificationCallbackControllerSpec extends ControllerUnitSpec with Mockito
 
     "return Accepted when the notification has been saved with susccess" in {
 
-      when(mockNotificationsService.save(any())).thenReturn(Future.successful(Right(())))
+      when(mockNotificationsService.parseAndSave(any())).thenReturn(Future.successful(Right(())))
 
       val result = controller.onNotify()(postRequest(<notification/>, "Authorization" -> expectedAuthToken))
 
@@ -57,7 +57,7 @@ class NotificationCallbackControllerSpec extends ControllerUnitSpec with Mockito
 
     "return internal server error when there is a downstream failure" in {
 
-      when(mockNotificationsService.save(any[NodeSeq])).thenReturn(Future.successful(Left(new IOException("Server error"))))
+      when(mockNotificationsService.parseAndSave(any[NodeSeq])).thenReturn(Future.successful(Left(new IOException("Server error"))))
 
       val result = controller.onNotify()(postRequest(<notification/>, "Authorization" -> expectedAuthToken))
 

--- a/test/unit/models/NotificationSpec.scala
+++ b/test/unit/models/NotificationSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import java.time.format.DateTimeFormatter
+
+import base.TestData._
+import org.joda.time.DateTime
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.libs.json.Json
+import reactivemongo.bson.BSONObjectID
+
+class NotificationSpec extends WordSpec with MustMatchers {
+  val formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME
+  val idVal = BSONObjectID.generate()
+
+  "Notifications Spec DbFormat" must {
+    val notification = Notification(idVal, payload, Some(NotificationDetails(fileReference, outcomeSuccess, filename)), dateTime)
+
+    "have json writes that produce a string which could be parsed by the database" in {
+      val json = Json.toJson(notification)(Notification.DbFormat.notificationFormat)
+
+      json.toString() mustBe NotificationSpec.serialisedDbFormat(idVal, fileReference, outcomeSuccess, filename, dateTime, payload)
+    }
+
+    "have json reads that produce object from the serialized database format" in {
+      val readNotification =
+        Json
+          .parse(NotificationSpec.serialisedDbFormat(idVal, fileReference, outcomeSuccess, filename, dateTime, payload))
+          .as[Notification](Notification.DbFormat.notificationFormat)
+
+      readNotification mustBe notification
+    }
+  }
+
+  "Notifications Spec FrontendFormat" must {
+    val notification = Notification(idVal, payload, Some(NotificationDetails(fileReference, outcomeSuccess, filename)), dateTime)
+
+    "have json writes that produce a string which could be parsed by the SFUS frontend" in {
+      val json = Json.toJson(notification)(Notification.FrontendFormat.writes)
+
+      json.toString() mustBe NotificationSpec.serialisedFrontEndFormat(fileReference, outcomeSuccess, filename, dateTime)
+    }
+  }
+}
+
+object NotificationSpec {
+  def serialisedDbFormat(idVal: BSONObjectID, fileReference: String, outcome: String, filename: String, dateTime: DateTime, payload: String) =
+    s"""{"_id":{"$$oid":"${idVal.stringify}"},"payload":"${payload}","details":{"fileReference":"${fileReference}","outcome":"${outcome}","filename":"${filename}"},"createdAt":{"$$date":${dateTime.getMillis}}}"""
+
+  def serialisedFrontEndFormat(ifileReference: String, outcome: String, filename: String, dateTime: DateTime) =
+    s"""{"fileReference":"${fileReference}","outcome":"${outcome}","filename":"${filename}","createdAt":{"$$date":${dateTime.getMillis}}}"""
+}


### PR DESCRIPTION
Before all Notification processing was a synchronous operation. In cases
where the service can not parse a Notification due to a change in its
structure, the notification data is lost as it is not inserted into
the MongoDB.

The implemented solution is:
1) The data parsed from a notification is now optional in the data
model.
2) All notifications payloads received are persisted to Mongo if they
are parsable or not.
3) A reattempt to parse 'routine' is run at app start up (after the
database migration jobs have finished) to query all unparsed
notifications and attempt to reprocess them.
4) A new database migration job created to migrate from the non-optional
notification parsed details model to the new optional structure.