### PR TITLE
[BAU] Restore ttl index name to its original value

### DIFF
--- a/app/repositories/NotificationsRepository.scala
+++ b/app/repositories/NotificationsRepository.scala
@@ -61,7 +61,7 @@ object NotificationRepository {
       IndexModel(
         ascending("createdAt"),
         IndexOptions()
-          .name("ttl")
+          .name("createdAtIndex")
           .expireAfter(appConfig.notificationsTtlSeconds, TimeUnit.SECONDS)
       )
     )


### PR DESCRIPTION
Due to Mongo ver 4.2 throwing error when attempting to rename an existing index.